### PR TITLE
interoperability tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,3 +34,4 @@ LDADD =
 include Make.rules
 
 include $(top_srcdir)/perf-regression/Makefile.subdir
+include $(top_srcdir)/interoperability/Makefile.subdir

--- a/interoperability/Makefile.subdir
+++ b/interoperability/Makefile.subdir
@@ -1,5 +1,5 @@
 if HAVE_MARGO
-bin_PROGRAMS += interoperability/margo-plus-non-margo
+bin_PROGRAMS += interoperability/margo-plus-non-margo interoperability/margo-calls-from-pthreads
 endif
 
 interoperability_margo_plus_non_margo_SOURCES = interoperability/margo-plus-non-margo.c interoperability/lib-nm.c

--- a/interoperability/Makefile.subdir
+++ b/interoperability/Makefile.subdir
@@ -2,3 +2,4 @@ if HAVE_MARGO
 bin_PROGRAMS += interoperability/margo-plus-non-margo
 endif
 
+interoperability_margo_plus_non_margo_SOURCES = interoperability/margo-plus-non-margo.c interoperability/lib-nm.c

--- a/interoperability/Makefile.subdir
+++ b/interoperability/Makefile.subdir
@@ -1,0 +1,4 @@
+if HAVE_MARGO
+bin_PROGRAMS += interoperability/margo-plus-non-margo
+endif
+

--- a/interoperability/README.md
+++ b/interoperability/README.md
@@ -4,7 +4,9 @@ This subdirectory contains demo programs that show how to use margo in
 conjunction with other technologies.
 
 * margo-plus-non-margo
-  * margo sharing access to Mercury with code that does not use margo.  The
-    non-margo code is found in lib-nm.[ch].  It deliberately sets up a
-    separate context on both the client and server to prevent callbacks from
-    mingling.
+  * Example: margo sharing access to Mercury with code that does not use
+    margo.  The non-margo code is found in lib-nm.[ch].  It sets up a
+    separate context to prevent callbacks from mingling.
+* margo-calls-from-pthreads
+  * Example: a margo program that also spawns pthreads that issue concurrent
+    margo forward calls.

--- a/interoperability/README.md
+++ b/interoperability/README.md
@@ -1,0 +1,10 @@
+# interoperability tests
+
+This subdirectory contains demo programs that show how to use margo in
+conjunction with other technologies.
+
+* margo-plus-non-margo
+  * margo sharing access to Mercury with code that does not use margo.  The
+    non-margo code is found in lib-nm.[ch].  It deliberately sets up a
+    separate context on both the client and server to prevent callbacks from
+    mingling.

--- a/interoperability/README.md
+++ b/interoperability/README.md
@@ -8,7 +8,10 @@ conjunction with other technologies.
     margo.  The non-margo code is found in lib-nm.[ch].  It sets up a
     separate context to prevent callbacks from mingling.
     * Note: as of Mercury 2.0rc1, this capability is not uniformly supported
-      across all transports.
+      across all transports.  You can confirm by looking at the output to
+      see if the noop_ult and nm_noop_rpc_cb are executed by the same tid or
+      not.  The are intended to execute on differnet tids if the context
+      functionality is working correctly.
 * margo-calls-from-pthreads
   * Example: a margo program that also spawns pthreads that issue concurrent
     margo forward calls.

--- a/interoperability/README.md
+++ b/interoperability/README.md
@@ -7,6 +7,8 @@ conjunction with other technologies.
   * Example: margo sharing access to Mercury with code that does not use
     margo.  The non-margo code is found in lib-nm.[ch].  It sets up a
     separate context to prevent callbacks from mingling.
+    * Note: as of Mercury 2.0rc1, this capability is not uniformly supported
+      across all transports.
 * margo-calls-from-pthreads
   * Example: a margo program that also spawns pthreads that issue concurrent
     margo forward calls.

--- a/interoperability/lib-nm.c
+++ b/interoperability/lib-nm.c
@@ -126,9 +126,15 @@ void* nm_run_client(void* _arg)
 
     printf("# (non-margo) client progress_fn tid: %lu\n", tid);
 
+    /* By creating handle in this context, we ensure that the callback from
+     * the *forward* call happens in the local progress thread.  It does not
+     * dictate what context will be used on the server, though.  We use
+     * HG_Set_target_id() to specify that.
+     */
     ret = HG_Create(pargs.context, nm_args->target_addr,
             nm_noop_id, &handle);
     assert(ret == HG_SUCCESS);
+    HG_Set_target_id(handle, NM_ID);
 
     ret = HG_Forward(handle, nm_noop_forward_cb, NULL, NULL);
     assert(ret == 0);

--- a/interoperability/lib-nm.c
+++ b/interoperability/lib-nm.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020 UChicago Argonne, LLC
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include <mercury.h>
+
+#include "lib-nm.h"
+
+void* nm_run_client(void* _arg)
+{
+    /* do stuff using raw mercury interface */
+    return(NULL);
+}
+
+void* nm_run_server(void* _arg)
+{
+    /* do stuff using raw mercury interface */
+    return(NULL);
+}

--- a/interoperability/lib-nm.c
+++ b/interoperability/lib-nm.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#include <pthread.h>
 
 #include <mercury.h>
 
@@ -15,18 +16,59 @@
 
 #define NM_ID 1
 
+static int shutdown_flag = 0;
+
+struct progress_fn_args
+{
+    hg_context_t *context;
+};
+
+void* progress_fn(void* _arg)
+{
+    struct progress_fn_args *pargs = _arg;
+    int ret;
+    unsigned int actual_count;
+
+    while(!shutdown_flag)
+    {
+        do{
+            ret = HG_Trigger(pargs->context, 0, 1, &actual_count);
+        }while((ret == HG_SUCCESS) && actual_count);
+
+        if(!shutdown_flag)
+            ret = HG_Progress(pargs->context, 100);
+
+        if(ret != HG_SUCCESS && ret != HG_TIMEOUT)
+        {
+            fprintf(stderr, "Error: unexpected HG_Progress() error code %d\n", ret);
+            assert(0);
+        }
+    }
+
+    return(NULL);
+}
+
 void* nm_run_client(void* _arg)
 {
     struct nm_client_args *nm_args = _arg;
-    hg_context_t *context;
+    struct progress_fn_args pargs;
+    pthread_t tid;
+    int ret;
 
     /* create separate context for this component */
-    context = HG_Context_create_id(nm_args->class, NM_ID);
-    assert(context);
+    pargs.context = HG_Context_create_id(nm_args->class, NM_ID);
+    assert(pargs.context);
+
+    /* create thread to drive progress */
+    ret = pthread_create(&tid, NULL, progress_fn, &pargs);
+    assert(ret == 0);
 
     sleep(1);
 
-    HG_Context_destroy(context);
+    shutdown_flag = 1;
+    pthread_join(tid, NULL);
+
+    HG_Context_destroy(pargs.context);
 
     return(NULL);
 }
@@ -34,15 +76,24 @@ void* nm_run_client(void* _arg)
 void* nm_run_server(void* _arg)
 {
     struct nm_server_args *nm_args = _arg;
-    hg_context_t *context;
+    struct progress_fn_args pargs;
+    pthread_t tid;
+    int ret;
 
     /* create separate context for this component */
-    context = HG_Context_create_id(nm_args->class, NM_ID);
-    assert(context);
+    pargs.context = HG_Context_create_id(nm_args->class, NM_ID);
+    assert(pargs.context);
+
+    /* create thread to drive progress */
+    ret = pthread_create(&tid, NULL, progress_fn, &pargs);
+    assert(ret == 0);
 
     sleep(1);
 
-    HG_Context_destroy(context);
+    shutdown_flag = 1;
+    pthread_join(tid, NULL);
+
+    HG_Context_destroy(pargs.context);
 
     return(NULL);
 }

--- a/interoperability/lib-nm.c
+++ b/interoperability/lib-nm.c
@@ -4,6 +4,15 @@
  * See COPYRIGHT in top-level directory.
  */
 
+/* Example non-margo code that can run in tandem with margo code.  The
+ * explicit differences from normal Mercury bootstrapping are:
+ *
+ * - assume that a class has already been set up by another party (margo in
+ *   this case)
+ * - create a separate context (with it's own id) in that class to prevent
+ *   interference
+ */
+
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>

--- a/interoperability/lib-nm.c
+++ b/interoperability/lib-nm.c
@@ -13,14 +13,36 @@
 
 #include "lib-nm.h"
 
+#define NM_ID 1
+
 void* nm_run_client(void* _arg)
 {
-    /* do stuff using raw mercury interface */
+    struct nm_client_args *nm_args = _arg;
+    hg_context_t *context;
+
+    /* create separate context for this component */
+    context = HG_Context_create_id(nm_args->class, NM_ID);
+    assert(context);
+
+    sleep(1);
+
+    HG_Context_destroy(context);
+
     return(NULL);
 }
 
 void* nm_run_server(void* _arg)
 {
-    /* do stuff using raw mercury interface */
+    struct nm_server_args *nm_args = _arg;
+    hg_context_t *context;
+
+    /* create separate context for this component */
+    context = HG_Context_create_id(nm_args->class, NM_ID);
+    assert(context);
+
+    sleep(1);
+
+    HG_Context_destroy(context);
+
     return(NULL);
 }

--- a/interoperability/lib-nm.h
+++ b/interoperability/lib-nm.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020 UChicago Argonne, LLC
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+#ifndef LIB_NM_H
+#define LIB_NM_H
+
+void* nm_run_client(void* _arg);
+void* nm_run_server(void* _arg);
+
+#endif /* LIB_NM_H */

--- a/interoperability/lib-nm.h
+++ b/interoperability/lib-nm.h
@@ -7,7 +7,17 @@
 #ifndef LIB_NM_H
 #define LIB_NM_H
 
+struct nm_client_args
+{
+    hg_class_t *class;
+    hg_addr_t target_addr;
+};
 void* nm_run_client(void* _arg);
+
+struct nm_server_args
+{
+    hg_class_t *class;
+};
 void* nm_run_server(void* _arg);
 
 #endif /* LIB_NM_H */

--- a/interoperability/margo-calls-from-pthreads.c
+++ b/interoperability/margo-calls-from-pthreads.c
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2020 UChicago Argonne, LLC
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+/* Example program demonstrating concurrent margo calls being invoked from
+ * different threads.
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <pthread.h>
+
+#include <mpi.h>
+
+#include <margo.h>
+#include <mercury.h>
+#include <abt.h>
+#include <ssg.h>
+#include <ssg-mpi.h>
+
+struct options
+{
+    char* na_transport;
+};
+
+static int parse_args(int argc, char **argv, struct options *opts);
+static void usage(void);
+DECLARE_MARGO_RPC_HANDLER(noop_ult);
+
+static hg_id_t noop_id;
+static struct options g_opts;
+static int rpcs_serviced = 0;
+static ABT_eventual rpcs_serviced_eventual;
+
+int main(int argc, char **argv)
+{
+    margo_instance_id mid;
+    int nranks;
+    int my_mpi_rank;
+    ssg_group_id_t gid;
+    char *gid_buffer;
+    size_t gid_buffer_size;
+    int gid_buffer_size_int;
+    int namelen;
+    char processor_name[MPI_MAX_PROCESSOR_NAME];
+    int group_size;
+    int ret;
+
+    MPI_Init(&argc, &argv);
+
+    /* 2 process test */
+    MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+    if(nranks != 2)
+    {
+        usage();
+        exit(EXIT_FAILURE);
+    }
+    MPI_Comm_rank(MPI_COMM_WORLD, &my_mpi_rank);
+    MPI_Get_processor_name(processor_name,&namelen);
+
+    ret = parse_args(argc, argv, &g_opts);
+    if(ret < 0)
+    {
+        if(my_mpi_rank == 0)
+            usage();
+        exit(EXIT_FAILURE);
+    }
+
+    /* actually start margo */
+    /* note: enabling progress thread to make sure margo rpcs remain
+     * responsive even if we block in pthread calls (for example)
+     */
+    mid = margo_init(g_opts.na_transport, MARGO_SERVER_MODE, 1, -1);
+    assert(mid);
+
+    noop_id = MARGO_REGISTER(
+        mid,
+        "noop_rpc",
+        void,
+        void,
+        noop_ult);
+
+    ret = ssg_init();
+    assert(ret == SSG_SUCCESS);
+
+    if(my_mpi_rank == 0)
+    {
+        /* set up server "group" on rank 0 */
+        gid = ssg_group_create_mpi(mid, "margo-p2p-latency", MPI_COMM_SELF, NULL, NULL, NULL);
+        assert(gid != SSG_GROUP_ID_INVALID);
+
+        /* load group info into a buffer */
+        ssg_group_id_serialize(gid, 1, &gid_buffer, &gid_buffer_size);
+        assert(gid_buffer && (gid_buffer_size > 0));
+        gid_buffer_size_int = (int)gid_buffer_size;
+    }
+
+    /* broadcast server group info to clients */
+    MPI_Bcast(&gid_buffer_size_int, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    if (my_mpi_rank == 1)
+    {
+        /* client ranks allocate a buffer for receiving GID buffer */
+        gid_buffer = calloc((size_t)gid_buffer_size_int, 1);
+        assert(gid_buffer);
+    }
+    MPI_Bcast(gid_buffer, gid_buffer_size_int, MPI_CHAR, 0, MPI_COMM_WORLD);
+
+    /* client observes server group */
+    if (my_mpi_rank == 1)
+    {
+        int count=1;
+        ssg_group_id_deserialize(gid_buffer, gid_buffer_size_int, &count, &gid);
+        assert(gid != SSG_GROUP_ID_INVALID);
+
+        ret = ssg_group_observe(mid, gid);
+        assert(ret == SSG_SUCCESS);
+    }
+
+    /* sanity check group size on server/client */
+    group_size = ssg_get_group_size(gid);
+    assert(group_size == 1);
+
+    if(my_mpi_rank == 1)
+    {
+        /* rank 1 runs client code */
+        hg_handle_t handle;
+        hg_addr_t target_addr;
+        int i;
+        int ret;
+
+        target_addr = ssg_get_group_member_addr(gid, ssg_get_group_member_id_from_rank(gid, 0));
+        assert(target_addr != HG_ADDR_NULL);
+
+        /* do margo stuff */
+        ret = margo_create(mid, target_addr, noop_id, &handle);
+        assert(ret == 0);
+
+        for(i=0; i<10; i++)
+        {
+            ret = margo_forward(handle, NULL);
+            assert(ret == 0);
+        }
+
+        margo_destroy(handle);
+
+        ret = ssg_group_unobserve(gid);
+        assert(ret == SSG_SUCCESS);
+    }
+    else
+    {
+        /* rank 0 acts as server */
+        ret = ABT_eventual_create(0, &rpcs_serviced_eventual);
+        assert(ret == 0);
+
+        /* wait for for margo service stuff to finish */
+        ABT_eventual_wait(rpcs_serviced_eventual, NULL);
+        assert(rpcs_serviced == (10));
+
+        /* wait a little for client to finish */
+        margo_thread_sleep(mid, 2000);
+
+        ret = ssg_group_destroy(gid);
+        assert(ret == SSG_SUCCESS);
+    }
+
+    ssg_finalize();
+
+    free(gid_buffer);
+
+    margo_finalize(mid);
+    MPI_Finalize();
+
+    return 0;
+}
+
+static int parse_args(int argc, char **argv, struct options *opts)
+{
+    int opt;
+
+    memset(opts, 0, sizeof(*opts));
+
+    while((opt = getopt(argc, argv, "n:")) != -1)
+    {
+        switch(opt)
+        {
+            case 'n':
+                opts->na_transport = strdup(optarg);
+                if(!opts->na_transport)
+                {
+                    perror("strdup");
+                    return(-1);
+                }
+                break;
+            default:
+                return(-1);
+        }
+    }
+
+    if(!opts->na_transport)
+        return(-1);
+
+    return(0);
+}
+
+static void usage(void)
+{
+    fprintf(stderr,
+        "Usage: margo-plus-non-margo -n <na>\n"
+        "\t\texample: mpiexec -n 2 ./margo-plus-non-margo -n verbs://\n");
+    return;
+}
+
+
+/* service a remote RPC for a no-op */
+static void noop_ult(hg_handle_t handle)
+{
+    margo_respond(handle, NULL);
+    margo_destroy(handle);
+
+    rpcs_serviced++;
+    if(rpcs_serviced == 10)
+        ABT_eventual_set(rpcs_serviced_eventual, NULL, 0);
+
+    return;
+}
+DEFINE_MARGO_RPC_HANDLER(noop_ult)
+

--- a/interoperability/margo-plus-non-margo.c
+++ b/interoperability/margo-plus-non-margo.c
@@ -4,6 +4,11 @@
  * See COPYRIGHT in top-level directory.
  */
 
+/* Example program demonstrating margo and non-margo users of Mercury in the
+ * same executable.  The margo code is in this file and runs in the main
+ * thread.  The non-margo code is in lib-nm.c and runs in a separate thread.
+ */
+
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>

--- a/interoperability/margo-plus-non-margo.c
+++ b/interoperability/margo-plus-non-margo.c
@@ -52,6 +52,7 @@ int main(int argc, char **argv)
     int group_size;
     int ret;
     pthread_t tid;
+    struct hg_init_info hii;
 
     MPI_Init(&argc, &argv);
 
@@ -80,7 +81,10 @@ int main(int argc, char **argv)
     /* note: enabling progress thread to make sure margo rpcs remain
      * responsive even if we block in pthread calls (for example)
      */
-    mid = margo_init(g_opts.na_transport, MARGO_SERVER_MODE, 1, -1);
+    memset(&hii, 0, sizeof(hii));
+    /* we will use one context for margo and one context for non-margo code */
+    hii.na_init_info.max_contexts = 2;
+    mid = margo_init_opt(g_opts.na_transport, MARGO_SERVER_MODE, &hii, 1, -1);
     assert(mid);
 
     noop_id = MARGO_REGISTER(

--- a/interoperability/margo-plus-non-margo.c
+++ b/interoperability/margo-plus-non-margo.c
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2020 UChicago Argonne, LLC
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include <mpi.h>
+
+#include <margo.h>
+#include <mercury.h>
+#include <abt.h>
+#include <ssg.h>
+#include <ssg-mpi.h>
+
+struct options
+{
+    char* na_transport;
+};
+
+static int parse_args(int argc, char **argv, struct options *opts);
+static void usage(void);
+DECLARE_MARGO_RPC_HANDLER(noop_ult);
+
+static hg_id_t noop_id;
+static struct options g_opts;
+
+int main(int argc, char **argv) 
+{
+    margo_instance_id mid;
+    int nranks;
+    int my_mpi_rank;
+    ssg_group_id_t gid;
+    char *gid_buffer;
+    size_t gid_buffer_size;
+    int gid_buffer_size_int;
+    int namelen;
+    char processor_name[MPI_MAX_PROCESSOR_NAME];
+    int group_size;
+    int ret;
+
+    MPI_Init(&argc, &argv);
+
+    /* 2 process test */
+    MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+    if(nranks != 2)
+    {
+        usage();
+        exit(EXIT_FAILURE);
+    }
+    MPI_Comm_rank(MPI_COMM_WORLD, &my_mpi_rank);
+    MPI_Get_processor_name(processor_name,&namelen);
+
+    ret = parse_args(argc, argv, &g_opts);
+    if(ret < 0)
+    {
+        if(my_mpi_rank == 0)
+            usage();
+        exit(EXIT_FAILURE);
+    }
+
+    /* actually start margo */
+    mid = margo_init(g_opts.na_transport, MARGO_SERVER_MODE, 0, -1);
+    assert(mid);
+
+    noop_id = MARGO_REGISTER(
+        mid,
+        "noop_rpc",
+        void,
+        void,
+        noop_ult);
+
+    ret = ssg_init();
+    assert(ret == SSG_SUCCESS);
+
+    if(my_mpi_rank == 0)
+    {
+        /* set up server "group" on rank 0 */
+        gid = ssg_group_create_mpi(mid, "margo-p2p-latency", MPI_COMM_SELF, NULL, NULL, NULL);
+        assert(gid != SSG_GROUP_ID_INVALID);
+
+        /* load group info into a buffer */
+        ssg_group_id_serialize(gid, 1, &gid_buffer, &gid_buffer_size);
+        assert(gid_buffer && (gid_buffer_size > 0));
+        gid_buffer_size_int = (int)gid_buffer_size;
+    }
+
+    /* broadcast server group info to clients */
+    MPI_Bcast(&gid_buffer_size_int, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    if (my_mpi_rank == 1)
+    {
+        /* client ranks allocate a buffer for receiving GID buffer */
+        gid_buffer = calloc((size_t)gid_buffer_size_int, 1);
+        assert(gid_buffer);
+    }
+    MPI_Bcast(gid_buffer, gid_buffer_size_int, MPI_CHAR, 0, MPI_COMM_WORLD);
+
+    /* client observes server group */
+    if (my_mpi_rank == 1)
+    {
+        int count=1;
+        ssg_group_id_deserialize(gid_buffer, gid_buffer_size_int, &count, &gid);
+        assert(gid != SSG_GROUP_ID_INVALID);
+
+        ret = ssg_group_observe(mid, gid);
+        assert(ret == SSG_SUCCESS);
+    }
+
+    /* sanity check group size on server/client */
+    group_size = ssg_get_group_size(gid);
+    assert(group_size == 1);
+
+    if(my_mpi_rank == 1)
+    {
+        /* rank 1 runs client code */
+
+        /* TODO: issue noop */
+
+        ret = ssg_group_unobserve(gid);
+        assert(ret == SSG_SUCCESS);
+    }
+    else
+    {
+        /* rank 0 acts as server */
+
+        /* for now, just wait a little for client to finish */
+        margo_thread_sleep(mid, 5000);
+
+        ret = ssg_group_destroy(gid);
+        assert(ret == SSG_SUCCESS);
+    }
+
+    ssg_finalize();
+
+    free(gid_buffer);
+
+    margo_finalize(mid);
+    MPI_Finalize();
+
+    return 0;
+}
+
+static int parse_args(int argc, char **argv, struct options *opts)
+{
+    int opt;
+
+    memset(opts, 0, sizeof(*opts));
+
+    while((opt = getopt(argc, argv, "n:")) != -1)
+    {
+        switch(opt)
+        {
+            case 'n':
+                opts->na_transport = strdup(optarg);
+                if(!opts->na_transport)
+                {
+                    perror("strdup");
+                    return(-1);
+                }
+                break;
+            default:
+                return(-1);
+        }
+    }
+
+    if(!opts->na_transport)
+        return(-1);
+
+    return(0);
+}
+
+static void usage(void)
+{
+    fprintf(stderr,
+        "Usage: margo-plus-non-margo -n <na>\n"
+        "\t\texample: mpiexec -n 2 ./margo-plus-non-margo -n verbs://\n");
+    return;
+}
+
+
+/* service a remote RPC for a no-op */
+static void noop_ult(hg_handle_t handle)
+{
+    margo_respond(handle, NULL);
+    margo_destroy(handle);
+
+    return;
+}
+DEFINE_MARGO_RPC_HANDLER(noop_ult)
+

--- a/interoperability/margo-plus-non-margo.c
+++ b/interoperability/margo-plus-non-margo.c
@@ -129,12 +129,15 @@ int main(int argc, char **argv)
         int i;
         int ret;
         pthread_t tid;
+        struct nm_client_args nm_args;
 
         target_addr = ssg_get_group_member_addr(gid, ssg_get_group_member_id_from_rank(gid, 0));
         assert(target_addr != HG_ADDR_NULL);
 
         /* create pthread to run some non-margo code */
-        ret = pthread_create(&tid, NULL, nm_run_server, NULL);
+        nm_args.class = margo_get_class(mid);
+        nm_args.target_addr = target_addr;
+        ret = pthread_create(&tid, NULL, nm_run_client, &nm_args);
         assert(ret == 0);
 
         /* do margo stuff */
@@ -159,12 +162,14 @@ int main(int argc, char **argv)
     {
         /* rank 0 acts as server */
         pthread_t tid;
+        struct nm_server_args nm_args;
 
         ret = ABT_eventual_create(0, &rpcs_serviced_eventual);
         assert(ret == 0);
 
         /* create pthread to run some non-margo code */
-        ret = pthread_create(&tid, NULL, nm_run_server, NULL);
+        nm_args.class = margo_get_class(mid);
+        ret = pthread_create(&tid, NULL, nm_run_server, &nm_args);
         assert(ret == 0);
 
         /* wait for for margo service stuff to finish */


### PR DESCRIPTION
In GitLab by @carns on Jul 17, 2020, 10:51

New subdirectory called "interoperability" for tests that are designed to check how Margo interacts with other technologies, rather than performance.

Currently includes 2 examples, one for margo and non-margo code to share a Mercury endpoint (does not work on most transports at present) and one to demonstrate using multiple pthreads to issue margo forward calls (*does* work).

Should probably be part of regression tests at some point; for now just saving code examples and making sure that they build.