### PR TITLE
node microbenchmark

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,7 @@ AM_CONDITIONAL([HAVE_MARGO], [test "x${have_mpi}" = x1 && test "x${have_margo}" 
 AM_CONDITIONAL([HAVE_BAKE], [test "x${have_mpi}" = x1 && test "x${have_bake_client}" = x1 && test "x${have_bake_server}" = x1 && test "x${have_ssg}" = x1 && test "x${have_ssg_mpi}" = x1])
 AM_CONDITIONAL([HAVE_PMDK], [test "x${have_libpmemobj}" = x1 && test "x${have_argobots}" = x1])
 AM_CONDITIONAL([HAVE_SSG], [test "x${have_ssg}" = x1 && test "x${have_ssg_mpi}" = x1])
+AM_CONDITIONAL([HAVE_MPI], [test "x${have_mpi}" = x1])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/perf-regression/Makefile.subdir
+++ b/perf-regression/Makefile.subdir
@@ -14,3 +14,7 @@ endif
 if HAVE_PMDK
 bin_PROGRAMS += perf-regression/pmdk-bw
 endif
+
+if HAVE_MPI
+bin_PROGRAMS += perf-regression/node-microbench
+endif

--- a/perf-regression/Makefile.subdir
+++ b/perf-regression/Makefile.subdir
@@ -16,5 +16,8 @@ bin_PROGRAMS += perf-regression/pmdk-bw
 endif
 
 if HAVE_MPI
+perf_regression_node_microbench_SOURCES = \
+ perf-regression/node-microbench.c \
+ perf-regression/node-microbench-util.c
 bin_PROGRAMS += perf-regression/node-microbench
 endif

--- a/perf-regression/Makefile.subdir
+++ b/perf-regression/Makefile.subdir
@@ -19,5 +19,6 @@ if HAVE_MPI
 perf_regression_node_microbench_SOURCES = \
  perf-regression/node-microbench.c \
  perf-regression/node-microbench-util.c
+perf_regression_node_microbench_LDADD = -lpthread
 bin_PROGRAMS += perf-regression/node-microbench
 endif

--- a/perf-regression/node-microbench-util.c
+++ b/perf-regression/node-microbench-util.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021 UChicago Argonne, LLC
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+
+#include "node-microbench-util.h"
+
+int fn_call_x_obj(int i)
+{
+    int j = i + i;
+
+    return (j);
+}

--- a/perf-regression/node-microbench-util.h
+++ b/perf-regression/node-microbench-util.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2021 UChicago Argonne, LLC
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+#ifndef __NODE_MICROBENCH_UTIL
+#define __NODE_MICROBENCH_UTIL
+
+int fn_call_x_obj(int i);
+
+#endif /* __NODE_MICROBENCH_UTIL */

--- a/perf-regression/node-microbench.c
+++ b/perf-regression/node-microbench.c
@@ -10,6 +10,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <sys/time.h>
+#include <time.h>
 
 #include <mpi.h>
 
@@ -33,6 +34,10 @@ static void test_fn_call_x_obj(long unsigned iters);
 
 static void test_mpi_wtime(long unsigned iters);
 static void test_gettimeofday(long unsigned iters);
+static void test_clock_gettime_realtime(long unsigned iters);
+static void test_clock_gettime_realtime_coarse(long unsigned iters);
+static void test_clock_gettime_monotonic(long unsigned iters);
+static void test_clock_gettime_monotonic_coarse(long unsigned iters);
 
 static struct options   g_opts;
 static struct test_case g_test_cases[]
@@ -41,6 +46,10 @@ static struct test_case g_test_cases[]
        {"fn_call_cross_object", test_fn_call_x_obj},
        {"mpi_wtime", test_mpi_wtime},
        {"gettimeofday", test_gettimeofday},
+       {"clock_gettime(REALTIME)", test_clock_gettime_realtime},
+       {"clock_gettime(REALTIME_COARSE)", test_clock_gettime_realtime_coarse},
+       {"clock_gettime(MONOTONIC)", test_clock_gettime_monotonic},
+       {"clock_gettime(MONOTONIC_COARSE)", test_clock_gettime_monotonic_coarse},
        {NULL, NULL}};
 
 int main(int argc, char** argv)
@@ -189,6 +198,50 @@ static void test_gettimeofday(long unsigned iters)
     struct timeval tv __attribute__((unused));
 
     for (i = 0; i < iters; i++) { gettimeofday(&tv, NULL); }
+
+    return;
+}
+
+/* how expensive is clock_gettime()? */
+static void test_clock_gettime_realtime(long unsigned iters)
+{
+    long unsigned   i;
+    struct timespec tp __attribute__((unused));
+
+    for (i = 0; i < iters; i++) { clock_gettime(CLOCK_REALTIME, &tp); }
+
+    return;
+}
+
+/* how expensive is clock_gettime()? */
+static void test_clock_gettime_realtime_coarse(long unsigned iters)
+{
+    long unsigned   i;
+    struct timespec tp __attribute__((unused));
+
+    for (i = 0; i < iters; i++) { clock_gettime(CLOCK_REALTIME_COARSE, &tp); }
+
+    return;
+}
+
+/* how expensive is clock_gettime()? */
+static void test_clock_gettime_monotonic(long unsigned iters)
+{
+    long unsigned   i;
+    struct timespec tp __attribute__((unused));
+
+    for (i = 0; i < iters; i++) { clock_gettime(CLOCK_MONOTONIC, &tp); }
+
+    return;
+}
+
+/* how expensive is clock_gettime()? */
+static void test_clock_gettime_monotonic_coarse(long unsigned iters)
+{
+    long unsigned   i;
+    struct timespec tp __attribute__((unused));
+
+    for (i = 0; i < iters; i++) { clock_gettime(CLOCK_MONOTONIC_COARSE, &tp); }
 
     return;
 }

--- a/perf-regression/node-microbench.c
+++ b/perf-regression/node-microbench.c
@@ -30,11 +30,14 @@ static void test_fn_call_normal(long unsigned iters);
 static void test_fn_call_inline(long unsigned iters);
 static void test_fn_call_x_obj(long unsigned iters);
 
+static void test_mpi_wtime(long unsigned iters);
+
 static struct options   g_opts;
 static struct test_case g_test_cases[]
     = {{"fn_call_normal", test_fn_call_normal},
        {"fn_call_inline", test_fn_call_inline},
        {"fn_call_cross_object", test_fn_call_x_obj},
+       {"mpi_wtime", test_mpi_wtime},
        {NULL, NULL}};
 
 int main(int argc, char** argv)
@@ -161,6 +164,17 @@ static void test_fn_call_x_obj(long unsigned iters)
     int           tmp = 1;
 
     for (i = 0; i < iters; i++) { tmp = fn_call_x_obj(tmp); }
+
+    return;
+}
+
+/* how expensive is MPI_Wtime()? */
+static void test_mpi_wtime(long unsigned iters)
+{
+    long unsigned i;
+    double        tm __attribute__((unused));
+
+    for (i = 0; i < iters; i++) { tm = MPI_Wtime(); }
 
     return;
 }

--- a/perf-regression/node-microbench.c
+++ b/perf-regression/node-microbench.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <assert.h>
 #include <stdlib.h>
+#include <sys/time.h>
 
 #include <mpi.h>
 
@@ -31,6 +32,7 @@ static void test_fn_call_inline(long unsigned iters);
 static void test_fn_call_x_obj(long unsigned iters);
 
 static void test_mpi_wtime(long unsigned iters);
+static void test_gettimeofday(long unsigned iters);
 
 static struct options   g_opts;
 static struct test_case g_test_cases[]
@@ -38,6 +40,7 @@ static struct test_case g_test_cases[]
        {"fn_call_inline", test_fn_call_inline},
        {"fn_call_cross_object", test_fn_call_x_obj},
        {"mpi_wtime", test_mpi_wtime},
+       {"gettimeofday", test_gettimeofday},
        {NULL, NULL}};
 
 int main(int argc, char** argv)
@@ -175,6 +178,17 @@ static void test_mpi_wtime(long unsigned iters)
     double        tm __attribute__((unused));
 
     for (i = 0; i < iters; i++) { tm = MPI_Wtime(); }
+
+    return;
+}
+
+/* how expensive is gettimeofday()? */
+static void test_gettimeofday(long unsigned iters)
+{
+    long unsigned  i;
+    struct timeval tv __attribute__((unused));
+
+    for (i = 0; i < iters; i++) { gettimeofday(&tv, NULL); }
 
     return;
 }

--- a/perf-regression/node-microbench.c
+++ b/perf-regression/node-microbench.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017 UChicago Argonne, LLC
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+
+#include <mpi.h>
+
+struct options {
+    long unsigned million_iterations;
+};
+
+static int  parse_args(int argc, char** argv, struct options* opts);
+static void usage(void);
+
+static struct options g_opts;
+
+int main(int argc, char** argv)
+{
+    int  nranks;
+    int  namelen;
+    char processor_name[MPI_MAX_PROCESSOR_NAME];
+    int  ret;
+
+    MPI_Init(&argc, &argv);
+
+    /* This is an MPI program (so that we can measure the cost of relevant
+     * MPI functions and so that we can easily launch on compute nodes) but
+     * it only uses one process.
+     */
+    MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+    if (nranks != 1) {
+        usage();
+        exit(EXIT_FAILURE);
+    }
+    MPI_Get_processor_name(processor_name, &namelen);
+
+    ret = parse_args(argc, argv, &g_opts);
+    if (ret < 0) {
+        usage();
+        exit(EXIT_FAILURE);
+    }
+
+    MPI_Finalize();
+
+    return 0;
+}
+
+static int parse_args(int argc, char** argv, struct options* opts)
+{
+    int opt;
+    int ret;
+
+    memset(opts, 0, sizeof(*opts));
+
+    while ((opt = getopt(argc, argv, "m:")) != -1) {
+        switch (opt) {
+        case 'm':
+            ret = sscanf(optarg, "%lu", &opts->million_iterations);
+            if (ret != 1) return (-1);
+            break;
+        default:
+            return (-1);
+        }
+    }
+
+    if (opts->million_iterations < 1) return (-1);
+
+    return (0);
+}
+
+static void usage(void)
+{
+    fprintf(stderr,
+            "Usage: "
+            "node-microbench -m <iterations (millions)>\n"
+            "\t\t(must be run with exactly 1 process)\n");
+    return;
+}

--- a/perf-regression/node-microbench.c
+++ b/perf-regression/node-microbench.c
@@ -23,11 +23,15 @@ struct test_case {
 
 static int  parse_args(int argc, char** argv, struct options* opts);
 static void usage(void);
+
 static void test_fn_call_normal(long unsigned iters);
+static void test_fn_call_inline(long unsigned iters);
 
 static struct options   g_opts;
 static struct test_case g_test_cases[]
-    = {{"fn_call_normal", test_fn_call_normal}, {NULL, NULL}};
+    = {{"fn_call_normal", test_fn_call_normal},
+       {"fn_call_inline", test_fn_call_inline},
+       {NULL, NULL}};
 
 int main(int argc, char** argv)
 {
@@ -111,6 +115,23 @@ static void usage(void)
     return;
 }
 
+static inline int fn_call_inline(int i)
+{
+    int j = i + i;
+
+    return (j);
+}
+
+/* how long does it take to issue an inline function call */
+static void test_fn_call_inline(long unsigned iters)
+{
+    long unsigned i;
+    int           tmp = 1;
+
+    for (i = 0; i < iters; i++) { tmp = fn_call_inline(tmp); }
+
+    return;
+}
 static int fn_call_normal(int i)
 {
     int j = i + i;

--- a/perf-regression/node-microbench.c
+++ b/perf-regression/node-microbench.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 UChicago Argonne, LLC
+ * Copyright (c) 2021 UChicago Argonne, LLC
  *
  * See COPYRIGHT in top-level directory.
  */
@@ -11,6 +11,8 @@
 #include <stdlib.h>
 
 #include <mpi.h>
+
+#include "node-microbench-util.h"
 
 struct options {
     long unsigned million_iterations;
@@ -26,11 +28,13 @@ static void usage(void);
 
 static void test_fn_call_normal(long unsigned iters);
 static void test_fn_call_inline(long unsigned iters);
+static void test_fn_call_x_obj(long unsigned iters);
 
 static struct options   g_opts;
 static struct test_case g_test_cases[]
     = {{"fn_call_normal", test_fn_call_normal},
        {"fn_call_inline", test_fn_call_inline},
+       {"fn_call_cross_object", test_fn_call_x_obj},
        {NULL, NULL}};
 
 int main(int argc, char** argv)
@@ -146,6 +150,17 @@ static void test_fn_call_normal(long unsigned iters)
     int           tmp = 1;
 
     for (i = 0; i < iters; i++) { tmp = fn_call_normal(tmp); }
+
+    return;
+}
+
+/* how long does it take to issue a function call to another object */
+static void test_fn_call_x_obj(long unsigned iters)
+{
+    long unsigned i;
+    int           tmp = 1;
+
+    for (i = 0; i < iters; i++) { tmp = fn_call_x_obj(tmp); }
 
     return;
 }


### PR DESCRIPTION
Simple benchmark to check sequential performance of node-local primitives (currently function calls, time calls, and locking primitives).