### PR TITLE
Argobots-specific eventual construct benchmarks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,12 @@ LIBS="$ARGOBOTS_LIBS $LIBS"
 CPPFLAGS="$ARGOBOTS_CFLAGS $CPPFLAGS"
 CFLAGS="$ARGOBOTS_CFLAGS $CFLAGS"
 
+# This is technically redundant with the above pkg-config check for
+# Argobots, but it is a straightforward way to also get a config.h #define
+# for the node-microbench utility to compile in optional Argobots tests
+AC_CHECK_HEADERS(abt.h,,
+  [AC_MSG_WARN([Could not find abt.h for Argobots])])
+
 PKG_CHECK_MODULES([LIBPMEMOBJ],[libpmemobj],[have_libpmemobj=1],
    [AC_MSG_WARN([Could not find working libpmemobj installation])])
 LIBS="$LIBPMEMOBJ_LIBS $LIBS"

--- a/perf-regression/node-microbench.c
+++ b/perf-regression/node-microbench.c
@@ -20,6 +20,9 @@
 #ifdef HAVE_X86INTRIN_H
     #include <x86intrin.h>
 #endif
+#ifdef HAVE_ABT_H
+    #include <abt.h>
+#endif
 
 #include <mpi.h>
 
@@ -54,6 +57,9 @@ static void test_stdatomic_lock(long unsigned iters);
 #ifdef HAVE_RDTSCP_INTRINSIC
 static void test_rdtscp(long unsigned iters);
 #endif
+#ifdef HAVE_ABT_H
+static void test_abt_eventual_dynamic_allocation(long unsigned iters);
+#endif
 
 static struct options   g_opts;
 static struct test_case g_test_cases[] = {
@@ -72,6 +78,9 @@ static struct test_case g_test_cases[] = {
     {"stdatomic lock/unlock", test_stdatomic_lock},
 #ifdef HAVE_RDTSCP_INTRINSIC
     {"rdtscp", test_rdtscp},
+#endif
+#ifdef HAVE_ABT_H
+    {"ABT_eventual dynamic per fn", test_abt_eventual_dynamic_allocation},
 #endif
     {NULL, NULL}};
 
@@ -347,3 +356,33 @@ static void test_rdtscp(long unsigned iters)
     return;
 }
 #endif /* HAVE_RDTSCP_INTRINSIC */
+
+#ifdef HAVE_ABT_H
+
+static void test_abt_eventual_dynamic_allocation_fn(void)
+{
+    int          ret;
+    ABT_eventual eventual;
+
+    ret = ABT_eventual_create(0, &eventual);
+    assert(ret == 0);
+
+    /* use it for something trivial */
+    ABT_eventual_set(eventual, NULL, 0);
+    ABT_eventual_wait(eventual, NULL);
+
+    ABT_eventual_free(&eventual);
+
+    return;
+}
+
+static void test_abt_eventual_dynamic_allocation(long unsigned iters)
+{
+    long unsigned i;
+
+    for (i = 0; i < iters; i++) test_abt_eventual_dynamic_allocation_fn();
+
+    return;
+}
+
+#endif /* HAVE_ABT_H */

--- a/perf-regression/node-microbench.c
+++ b/perf-regression/node-microbench.c
@@ -59,6 +59,9 @@ static void test_rdtscp(long unsigned iters);
 #endif
 #ifdef HAVE_ABT_H
 static void test_abt_eventual_dynamic_allocation(long unsigned iters);
+    #ifdef ABT_EVENTUAL_INITIALIZER
+static void test_abt_eventual_static_allocation(long unsigned iters);
+    #endif
 #endif
 
 static struct options   g_opts;
@@ -81,6 +84,9 @@ static struct test_case g_test_cases[] = {
 #endif
 #ifdef HAVE_ABT_H
     {"ABT_eventual dynamic per fn", test_abt_eventual_dynamic_allocation},
+    #ifdef ABT_EVENTUAL_INITIALIZER
+    {"ABT_eventual static per fn", test_abt_eventual_static_allocation},
+    #endif
 #endif
     {NULL, NULL}};
 
@@ -392,5 +398,31 @@ static void test_abt_eventual_dynamic_allocation(long unsigned iters)
 
     return;
 }
+
+    /* introduced in Argobots > 1.1 */
+    #ifdef ABT_EVENTUAL_INITIALIZER
+
+static void test_abt_eventual_static_allocation_fn(void)
+{
+    ABT_eventual_memory eventual_mem = ABT_EVENTUAL_INITIALIZER;
+    ABT_eventual eventual = ABT_EVENTUAL_MEMORY_GET_HANDLE(&eventual_mem);
+
+    /* use it for something trivial */
+    ABT_eventual_set(eventual, NULL, 0);
+    ABT_eventual_wait(eventual, NULL);
+
+    return;
+}
+
+static void test_abt_eventual_static_allocation(long unsigned iters)
+{
+    long unsigned i;
+
+    for (i = 0; i < iters; i++) test_abt_eventual_static_allocation_fn();
+
+    return;
+}
+
+    #endif /* ABT_EVENTUAL_INITIALIZER */
 
 #endif /* HAVE_ABT_H */

--- a/perf-regression/node-microbench.c
+++ b/perf-regression/node-microbench.c
@@ -93,6 +93,10 @@ int main(int argc, char** argv)
     int    test_idx = 0;
     double tm1, tm2;
 
+#ifdef HAVE_ABT_H
+    ABT_init(0, NULL);
+#endif
+
     MPI_Init(&argc, &argv);
 
     /* This is an MPI program (so that we can measure the cost of relevant
@@ -130,6 +134,10 @@ int main(int argc, char** argv)
     }
 
     MPI_Finalize();
+
+#ifdef HAVE_ABT_H
+    ABT_finalize();
+#endif
 
     return 0;
 }


### PR DESCRIPTION
Detects Argobots at configure time, conditionally enabling another subset of tests.

The first ones are intended to compare eventuals with static and dynamic allocation per function.