### PR TITLE
benchmark for concurrent ABT eventual performance

### DIFF
--- a/interoperability/margo-calls-from-pthreads.c
+++ b/interoperability/margo-calls-from-pthreads.c
@@ -145,7 +145,6 @@ int main(int argc, char** argv)
     if (my_mpi_rank == 1) {
         /* rank 1 runs client code */
         int                           i;
-        int                           ret;
         pthread_t                     tid_array[NTHREADS];
         struct pthread_client_fn_args pargs;
         ssg_member_id_t               target_id;

--- a/interoperability/margo-plus-non-margo.c
+++ b/interoperability/margo-plus-non-margo.c
@@ -137,8 +137,6 @@ int main(int argc, char** argv)
         hg_handle_t           handle;
         hg_addr_t             target_addr;
         int                   i;
-        int                   ret;
-        pthread_t             tid;
         struct nm_client_args nm_args;
         ssg_member_id_t       target_id;
 
@@ -170,7 +168,6 @@ int main(int argc, char** argv)
         pthread_join(tid, NULL);
     } else {
         /* rank 0 acts as server */
-        pthread_t             tid;
         struct nm_server_args nm_args;
 
         ret = ABT_eventual_create(0, &rpcs_serviced_eventual);

--- a/perf-regression/Makefile.subdir
+++ b/perf-regression/Makefile.subdir
@@ -1,5 +1,5 @@
 if HAVE_MARGO
-bin_PROGRAMS += perf-regression/margo-p2p-latency perf-regression/margo-p2p-bw perf-regression/margo-p2p-vector
+bin_PROGRAMS += perf-regression/margo-p2p-latency perf-regression/margo-p2p-bw perf-regression/margo-p2p-vector perf-regression/abt-eventual-bench
 endif
 
 if HAVE_SSG

--- a/perf-regression/Makefile.subdir
+++ b/perf-regression/Makefile.subdir
@@ -1,5 +1,9 @@
 if HAVE_MARGO
-bin_PROGRAMS += perf-regression/margo-p2p-latency perf-regression/margo-p2p-bw perf-regression/margo-p2p-vector perf-regression/abt-eventual-bench
+bin_PROGRAMS += perf-regression/margo-p2p-latency \
+		perf-regression/margo-p2p-bw \
+		perf-regression/margo-p2p-vector \
+		perf-regression/abt-eventual-bench\
+		perf-regression/abt-future-bench
 endif
 
 if HAVE_SSG

--- a/perf-regression/README.md
+++ b/perf-regression/README.md
@@ -48,3 +48,72 @@ mpiexec -n 2 ./margo-p2p-bw -x 4096 -n sm:// -c 1 -D 10
 -n is transport to use
 -c is the concurrency level
 -D is the duration of the test (for each direction)
+
+
+## abt-eventual-bench
+
+abt-eventual-bench measures how well we can create/wait/set/destroy concurrent
+eventuals. It approximates a concurrent mochi provider workload by creating N
+concurrent threads, each of which (in a loop) creates detached sub-threads that
+`margo_thread_sleep()` for a specified amount of time before setting an eventual
+and exiting. The sleep is a stand-in for waiting on network activity.
+
+Example, with a duration of 5 seconds, a sleep interval of 1 ms, and 16 ULTs:
+
+```
+$ ./abt-eventual-bench -d 5 -i 1 -n 16
+#<num_ults>	<test_duration_sec>	<interval_msec>	<ops/s>	<cpu_time_sec>
+16	5	1	15952.800000	4.255606
+```
+
+The above example shows 16 ULTs getting nearly 16,000 operations per second,
+which is pretty much ideal (each can do 1000 per second if everything is
+working right because there is a 1ms delay in each operation). The last column
+shows CPU time. In this case a 5 second run took 4.2 seconds of user-space CPU
+time, which is not expected.
+
+These results are most interesting if you sweep across a range of ULT counts to
+see how behavior changes with scale. There are scripts (in the 'tests'
+subdirectory) included in this repository to do this and plot the results for
+an example scenario. he first takes the eventual executable as it's argument
+(so that it can account for different build directories). The second takes the
+.dat file produced by the first script as it's argument and produces two plots.
+
+### Generating the data:
+
+```
+> tests/sweep-abt-eventual-bench.sh build/perf-regression/abt-eventual-bench
+writing results to sweep-abt-eventual-bench.1122789.dat
+... running benchmark with 100 ULTs
+... running benchmark with 200 ULTs
+... running benchmark with 300 ULTs
+... running benchmark with 400 ULTs
+... running benchmark with 500 ULTs
+... running benchmark with 600 ULTs
+... running benchmark with 700 ULTs
+... running benchmark with 800 ULTs
+... running benchmark with 900 ULTs
+... running benchmark with 1000 ULTs
+results are in sweep-abt-eventual-bench.1122789.dat
+```
+
+#### A note about job schedulers
+
+If you are running on a machine that requires you to submit jobs to compute
+nodes, we typically obtain an interactive node and then pass the job launching
+parts to the run script.  For example on Summit:
+
+```
+$ bsub -W 0:10 -nnodes 1 -P ${PROJECT} -Is /bin/bash
+...
+$ ../tests/sweep-abt-eventual-bench.sh jsrun -r1 -n1 -a1 perf-regression/abt-eventual-bench
+```
+
+### Plotting the results:
+
+```
+> tests/plot-abt-eventual-bench.sh sweep-abt-eventual-bench.1122789.dat
+> ls *.png
+sweep-abt-eventual-bench.1122789.dat.cpu.png
+sweep-abt-eventual-bench.1122789.dat.rate.png
+```

--- a/perf-regression/abt-eventual-bench.c
+++ b/perf-regression/abt-eventual-bench.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2021 UChicago Argonne, LLC
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+#define _GNU_SOURCE
+
+#include "sds-tests-config.h"
+
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <time.h>
+#include <pthread.h>
+
+#include <abt.h>
+#include <margo.h>
+
+#include <mpi.h>
+
+struct options {
+    int test_duration_sec;
+    int interval_msec;
+    int num_ults;
+};
+
+struct bench_thread_arg {
+    margo_instance_id mid;
+    int               completed_ops;
+    ABT_thread        tid;
+    ABT_barrier       barrier;
+    ABT_eventual      eventual;
+    ABT_pool          pool;
+};
+
+static int  parse_args(int argc, char** argv, struct options* opts);
+static void usage(void);
+static void bench_thread(void* _arg);
+static void ev_thread(void* _arg);
+
+static struct options g_opts;
+static double         g_start_tm;
+
+int main(int argc, char** argv)
+{
+    int                      nranks;
+    int                      namelen;
+    char                     processor_name[MPI_MAX_PROCESSOR_NAME];
+    int                      ret;
+    margo_instance_id        mid;
+    struct bench_thread_arg* arg_array;
+    int                      i;
+    ABT_pool                 pool;
+    ABT_xstream              xstream;
+    ABT_barrier              barrier;
+    int                      total_ops = 0;
+
+    MPI_Init(&argc, &argv);
+
+    /* Maybe be more configurable later, but for now just start a simple
+     * Margo instances with local sm communication and no extra threads
+     */
+    mid = margo_init("na+sm://", MARGO_CLIENT_MODE, 0, 0);
+    assert(mid);
+
+    /* This is an MPI program (so that we can measure the cost of relevant
+     * MPI functions and so that we can easily launch on compute nodes) but
+     * it only uses one process.
+     */
+    MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+    if (nranks != 1) {
+        usage();
+        exit(EXIT_FAILURE);
+    }
+    MPI_Get_processor_name(processor_name, &namelen);
+
+    ret = parse_args(argc, argv, &g_opts);
+    if (ret < 0) {
+        usage();
+        exit(EXIT_FAILURE);
+    }
+
+    ret = ABT_xstream_self(&xstream);
+    assert(ret == 0);
+
+    ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
+    assert(ret == 0);
+
+    ret = ABT_barrier_create(g_opts.num_ults + 1, &barrier);
+    assert(ret == 0);
+
+    arg_array = calloc(g_opts.num_ults, sizeof(*arg_array));
+    assert(arg_array);
+    for (i = 0; i < g_opts.num_ults; i++) {
+        arg_array[i].mid     = mid;
+        arg_array[i].barrier = barrier;
+        arg_array[i].pool    = pool;
+        ret = ABT_thread_create(pool, bench_thread, &arg_array[i],
+                                ABT_THREAD_ATTR_NULL, &arg_array[i].tid);
+        assert(ret == 0);
+    }
+
+    /* set global start time and release barrier for threads to work */
+    g_start_tm = ABT_get_wtime();
+    ABT_barrier_wait(barrier);
+
+    for (i = 0; i < g_opts.num_ults; i++) {
+        ABT_thread_join(arg_array[i].tid);
+        ABT_thread_free(&arg_array[i].tid);
+        total_ops += arg_array[i].completed_ops;
+    }
+
+    printf("#<num_ults>\t<test_duration_sec>\t<interval_msec>\t<ops/s>\n");
+    printf("%d\t%d\t%d\t%f\n", g_opts.num_ults, g_opts.test_duration_sec,
+           g_opts.interval_msec,
+           ((double)total_ops / (double)g_opts.test_duration_sec));
+
+    ABT_barrier_free(&barrier);
+    free(arg_array);
+    margo_finalize(mid);
+    MPI_Finalize();
+
+    return 0;
+}
+
+static int parse_args(int argc, char** argv, struct options* opts)
+{
+    int opt;
+    int ret;
+
+    memset(opts, 0, sizeof(*opts));
+
+    /* default values */
+    opts->test_duration_sec = 5;
+    opts->interval_msec     = 1;
+    opts->num_ults          = 1;
+
+    while ((opt = getopt(argc, argv, "d:i:n:")) != -1) {
+        switch (opt) {
+        case 'd':
+            ret = sscanf(optarg, "%d", &opts->test_duration_sec);
+            if (ret != 1) return (-1);
+            break;
+        case 'i':
+            ret = sscanf(optarg, "%d", &opts->interval_msec);
+            if (ret != 1) return (-1);
+            break;
+        case 'n':
+            ret = sscanf(optarg, "%d", &opts->num_ults);
+            if (ret != 1) return (-1);
+            break;
+        default:
+            return (-1);
+        }
+    }
+
+    if (opts->test_duration_sec < 1) return (-1);
+    if (opts->interval_msec < 1) return (-1);
+    if (opts->num_ults < 1) return (-1);
+
+    return (0);
+}
+
+static void usage(void)
+{
+    fprintf(stderr,
+            "Usage: "
+            "abt-eventual-bench [-d duration_seconds] [-i "
+            "interval_milliseconds] [-n number_of_ults]>\n"
+            "\t\t(must be run with exactly 1 process)\n");
+    return;
+}
+
+static void bench_thread(void* _arg)
+{
+    struct bench_thread_arg* arg = _arg;
+    int                      ret;
+
+    arg->completed_ops = 0;
+
+    ABT_barrier_wait(arg->barrier);
+
+    while ((ABT_get_wtime() - g_start_tm) < g_opts.test_duration_sec) {
+        /* every iteration we create a new eventual, create a new (detached)
+         * thread, and wait on eventual
+         */
+        ABT_eventual_create(0, &arg->eventual);
+
+        ret = ABT_thread_create(arg->pool, ev_thread, arg, ABT_THREAD_ATTR_NULL,
+                                NULL);
+        assert(ret == 0);
+        ABT_eventual_wait(arg->eventual, NULL);
+        ABT_eventual_free(&arg->eventual);
+        arg->completed_ops++;
+    }
+
+    return;
+}
+
+static void ev_thread(void* _arg)
+{
+    struct bench_thread_arg* arg = _arg;
+
+    /* TODO: make argument a double so we can do partial ms too */
+    margo_thread_sleep(arg->mid, g_opts.interval_msec);
+    ABT_eventual_set(arg->eventual, NULL, 0);
+
+    return;
+}

--- a/perf-regression/abt-eventual-bench.c
+++ b/perf-regression/abt-eventual-bench.c
@@ -22,8 +22,6 @@
 #include <abt.h>
 #include <margo.h>
 
-#include <mpi.h>
-
 struct options {
     int test_duration_sec;
     int interval_msec;
@@ -49,9 +47,6 @@ static double         g_start_tm;
 
 int main(int argc, char** argv)
 {
-    int                      nranks;
-    int                      namelen;
-    char                     processor_name[MPI_MAX_PROCESSOR_NAME];
     int                      ret;
     margo_instance_id        mid;
     struct bench_thread_arg* arg_array;
@@ -63,24 +58,11 @@ int main(int argc, char** argv)
     struct rusage            use;
     double                   user_cpu_seconds1, user_cpu_seconds2;
 
-    MPI_Init(&argc, &argv);
-
     /* Maybe be more configurable later, but for now just start a simple
      * Margo instances with local sm communication and no extra threads
      */
     mid = margo_init("na+sm://", MARGO_CLIENT_MODE, 0, 0);
     assert(mid);
-
-    /* This is an MPI program (so that we can measure the cost of relevant
-     * MPI functions and so that we can easily launch on compute nodes) but
-     * it only uses one process.
-     */
-    MPI_Comm_size(MPI_COMM_WORLD, &nranks);
-    if (nranks != 1) {
-        usage();
-        exit(EXIT_FAILURE);
-    }
-    MPI_Get_processor_name(processor_name, &namelen);
 
     ret = parse_args(argc, argv, &g_opts);
     if (ret < 0) {
@@ -140,7 +122,6 @@ int main(int argc, char** argv)
     ABT_barrier_free(&barrier);
     free(arg_array);
     margo_finalize(mid);
-    MPI_Finalize();
 
     return 0;
 }

--- a/perf-regression/abt-future-bench.c
+++ b/perf-regression/abt-future-bench.c
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2021 UChicago Argonne, LLC
+ *
+ * See COPYRIGHT in top-level directory.
+ */
+
+#define _GNU_SOURCE
+
+#include "sds-tests-config.h"
+
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <time.h>
+#include <pthread.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+
+#include <abt.h>
+#include <margo.h>
+
+#include <mpi.h>
+
+struct options {
+    int test_duration_sec;
+    int interval_msec;
+    int num_ults;
+};
+
+struct bench_thread_arg {
+    margo_instance_id mid;
+    int               completed_ops;
+    ABT_thread        tid;
+    ABT_barrier       barrier;
+    ABT_future        future;
+    ABT_pool          pool;
+};
+
+static int  parse_args(int argc, char** argv, struct options* opts);
+static void usage(void);
+static void bench_thread(void* _arg);
+static void ev_thread(void* _arg);
+
+static struct options g_opts;
+static double         g_start_tm;
+
+int main(int argc, char** argv)
+{
+    int                      nranks;
+    int                      namelen;
+    char                     processor_name[MPI_MAX_PROCESSOR_NAME];
+    int                      ret;
+    margo_instance_id        mid;
+    struct bench_thread_arg* arg_array;
+    int                      i;
+    ABT_pool                 pool;
+    ABT_xstream              xstream;
+    ABT_barrier              barrier;
+    int                      total_ops = 0;
+    struct rusage            use;
+    double                   user_cpu_seconds1, user_cpu_seconds2;
+
+    MPI_Init(&argc, &argv);
+
+    /* Maybe be more configurable later, but for now just start a simple
+     * Margo instances with local sm communication and no extra threads
+     */
+    mid = margo_init("na+sm://", MARGO_CLIENT_MODE, 0, 0);
+    assert(mid);
+
+    /* This is an MPI program (so that we can measure the cost of relevant
+     * MPI functions and so that we can easily launch on compute nodes) but
+     * it only uses one process.
+     */
+    MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+    if (nranks != 1) {
+        usage();
+        exit(EXIT_FAILURE);
+    }
+    MPI_Get_processor_name(processor_name, &namelen);
+
+    ret = parse_args(argc, argv, &g_opts);
+    if (ret < 0) {
+        usage();
+        exit(EXIT_FAILURE);
+    }
+
+    ret = ABT_xstream_self(&xstream);
+    assert(ret == 0);
+
+    ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
+    assert(ret == 0);
+
+    ret = ABT_barrier_create(g_opts.num_ults + 1, &barrier);
+    assert(ret == 0);
+
+    arg_array = calloc(g_opts.num_ults, sizeof(*arg_array));
+    assert(arg_array);
+    for (i = 0; i < g_opts.num_ults; i++) {
+        arg_array[i].mid     = mid;
+        arg_array[i].barrier = barrier;
+        arg_array[i].pool    = pool;
+        ret = ABT_thread_create(pool, bench_thread, &arg_array[i],
+                                ABT_THREAD_ATTR_NULL, &arg_array[i].tid);
+        assert(ret == 0);
+    }
+
+    /* start capturing cpu time */
+    ret = getrusage(RUSAGE_SELF, &use);
+    assert(ret == 0);
+    user_cpu_seconds1 = (double)use.ru_utime.tv_sec
+                      + (double)use.ru_utime.tv_usec / 1000000.0;
+
+    /* set global start time and release barrier for threads to work */
+    g_start_tm = ABT_get_wtime();
+    ABT_barrier_wait(barrier);
+
+    for (i = 0; i < g_opts.num_ults; i++) {
+        ABT_thread_join(arg_array[i].tid);
+        ABT_thread_free(&arg_array[i].tid);
+        total_ops += arg_array[i].completed_ops;
+    }
+
+    ret = getrusage(RUSAGE_SELF, &use);
+    assert(ret == 0);
+    user_cpu_seconds2 = (double)use.ru_utime.tv_sec
+                      + (double)use.ru_utime.tv_usec / 1000000.0;
+
+    printf(
+        "#<num_ults>\t<test_duration_sec>\t<interval_msec>\t<ops/"
+        "s>\t<cpu_time_sec>\n");
+    printf("%d\t%d\t%d\t%f\t%f\n", g_opts.num_ults, g_opts.test_duration_sec,
+           g_opts.interval_msec,
+           ((double)total_ops / (double)g_opts.test_duration_sec),
+           user_cpu_seconds2 - user_cpu_seconds1);
+
+    ABT_barrier_free(&barrier);
+    free(arg_array);
+    margo_finalize(mid);
+    MPI_Finalize();
+
+    return 0;
+}
+
+static int parse_args(int argc, char** argv, struct options* opts)
+{
+    int opt;
+    int ret;
+
+    memset(opts, 0, sizeof(*opts));
+
+    /* default values */
+    opts->test_duration_sec = 5;
+    opts->interval_msec     = 1;
+    opts->num_ults          = 1;
+
+    while ((opt = getopt(argc, argv, "d:i:n:")) != -1) {
+        switch (opt) {
+        case 'd':
+            ret = sscanf(optarg, "%d", &opts->test_duration_sec);
+            if (ret != 1) return (-1);
+            break;
+        case 'i':
+            ret = sscanf(optarg, "%d", &opts->interval_msec);
+            if (ret != 1) return (-1);
+            break;
+        case 'n':
+            ret = sscanf(optarg, "%d", &opts->num_ults);
+            if (ret != 1) return (-1);
+            break;
+        default:
+            return (-1);
+        }
+    }
+
+    if (opts->test_duration_sec < 1) return (-1);
+    if (opts->interval_msec < 1) return (-1);
+    if (opts->num_ults < 1) return (-1);
+
+    return (0);
+}
+
+static void usage(void)
+{
+    fprintf(stderr,
+            "Usage: "
+            "abt-future-bench [-d duration_seconds] [-i "
+            "interval_milliseconds] [-n number_of_ults]>\n"
+            "\t\t(must be run with exactly 1 process)\n");
+    return;
+}
+
+static void bench_thread(void* _arg)
+{
+    struct bench_thread_arg* arg = _arg;
+    int                      ret;
+
+    arg->completed_ops = 0;
+
+    ABT_barrier_wait(arg->barrier);
+
+    while ((ABT_get_wtime() - g_start_tm) < g_opts.test_duration_sec) {
+        /* every iteration we create a new future, create a new (detached)
+         * thread, and wait on future
+         */
+        ABT_future_create(1, NULL, &arg->future);
+
+        ret = ABT_thread_create(arg->pool, ev_thread, arg, ABT_THREAD_ATTR_NULL,
+                                NULL);
+        assert(ret == 0);
+        ABT_future_wait(arg->future);
+        ABT_future_free(&arg->future);
+        arg->completed_ops++;
+    }
+
+    return;
+}
+
+static void ev_thread(void* _arg)
+{
+    struct bench_thread_arg* arg = _arg;
+
+    /* TODO: make argument a double so we can do partial ms too */
+    margo_thread_sleep(arg->mid, g_opts.interval_msec);
+    ABT_future_set(arg->future, 0);
+
+    return;
+}

--- a/perf-regression/margo-p2p-bw.c
+++ b/perf-regression/margo-p2p-bw.c
@@ -278,7 +278,7 @@ int main(int argc, char** argv)
     }
 
     if (my_mpi_rank == 1) {
-        ssg_member_id_t target;
+        ssg_member_id_t ssg_target;
         /* TODO: this is a hack; we need a better way to wait for services
          * to be ready.  MPI Barriers aren't safe without setting aside
          * threads to make sure that servers can answer RPCs.
@@ -288,7 +288,7 @@ int main(int argc, char** argv)
 
         /* rank 1 (client) initiates benchmark */
 
-        ret = ssg_get_group_member_id_from_rank(gid, 0, &target);
+        ret = ssg_get_group_member_id_from_rank(gid, 0, &ssg_target);
         assert(ret == SSG_SUCCESS);
 
         /* warmup */
@@ -546,7 +546,7 @@ static void bw_ult(hg_handle_t handle)
 DEFINE_MARGO_RPC_HANDLER(bw_ult)
 
 static int run_benchmark(hg_id_t           id,
-                         ssg_member_id_t   target,
+                         ssg_member_id_t   ssg_target,
                          ssg_group_id_t    gid,
                          margo_instance_id mid,
                          int               shutdown,

--- a/perf-regression/margo-p2p-latency.c
+++ b/perf-regression/margo-p2p-latency.c
@@ -41,7 +41,7 @@ static int  run_benchmark(int               warmup_iterations,
                           int               iterations,
                           int               payload_size,
                           hg_id_t           id,
-                          ssg_member_id_t   target,
+                          ssg_member_id_t   ssg_target,
                           ssg_group_id_t    gid,
                           margo_instance_id mid,
                           double*           measurement_array,
@@ -165,17 +165,17 @@ int main(int argc, char** argv)
     assert(ret == SSG_SUCCESS);
 
     if (my_mpi_rank == 1) {
-        ssg_member_id_t target;
+        ssg_member_id_t ssg_target;
         /* rank 1 runs client benchmark */
 
         measurement_array
             = calloc(g_opts.iterations, sizeof(*measurement_array));
         assert(measurement_array);
 
-        ret = ssg_get_group_member_id_from_rank(gid, 0, &target);
+        ret = ssg_get_group_member_id_from_rank(gid, 0, &ssg_target);
         assert(ret == SSG_SUCCESS);
         ret = run_benchmark(g_opts.warmup_iterations, g_opts.iterations,
-                            g_opts.xfer_size, noop_id, target, gid, mid,
+                            g_opts.xfer_size, noop_id, ssg_target, gid, mid,
                             measurement_array, g_opts.margo_forward_timed_flag);
         assert(ret == 0);
 
@@ -324,7 +324,7 @@ static int run_benchmark(int               warmup_iterations,
                          int               iterations,
                          int               payload_size,
                          hg_id_t           id,
-                         ssg_member_id_t   target,
+                         ssg_member_id_t   ssg_target,
                          ssg_group_id_t    gid,
                          margo_instance_id mid,
                          double*           measurement_array,
@@ -338,7 +338,7 @@ static int run_benchmark(int               warmup_iterations,
     noop_in_t   in;
     noop_out_t  out;
 
-    ret = ssg_get_group_member_addr(gid, target, &target_addr);
+    ret = ssg_get_group_member_addr(gid, ssg_target, &target_addr);
     assert(ret == SSG_SUCCESS);
 
     ret = margo_create(mid, target_addr, id, &handle);

--- a/perf-regression/margo-p2p-vector.c
+++ b/perf-regression/margo-p2p-vector.c
@@ -107,7 +107,6 @@ int main(int argc, char** argv)
     int                    gid_buffer_size_int;
     int                    namelen;
     char                   processor_name[MPI_MAX_PROCESSOR_NAME];
-    int                    i;
     ABT_xstream*           bw_worker_xstreams = NULL;
     ABT_sched*             bw_worker_scheds   = NULL;
     struct margo_init_info mii;
@@ -292,7 +291,7 @@ int main(int argc, char** argv)
     }
 
     if (my_mpi_rank == 1) {
-        ssg_member_id_t target;
+        ssg_member_id_t ssg_target;
         /* TODO: this is a hack; we need a better way to wait for services
          * to be ready.  MPI Barriers aren't safe without setting aside
          * threads to make sure that servers can answer RPCs.
@@ -302,7 +301,7 @@ int main(int argc, char** argv)
 
         /* rank 1 (client) initiates benchmark */
 
-        ret = ssg_get_group_member_id_from_rank(gid, 0, &target);
+        ret = ssg_get_group_member_id_from_rank(gid, 0, &ssg_target);
         assert(ret == SSG_SUCCESS);
 
         /* warmup */
@@ -315,6 +314,7 @@ int main(int argc, char** argv)
                             g_opts.duration_seconds, 1);
         assert(ret == 0);
     } else {
+        int i;
         /* rank 0 (server) waits for test RPC to complete */
 
         ABT_eventual_wait(g_bw_done_eventual, NULL);
@@ -547,7 +547,7 @@ static void bw_ult(hg_handle_t handle)
 DEFINE_MARGO_RPC_HANDLER(bw_ult)
 
 static int run_benchmark(hg_id_t           id,
-                         ssg_member_id_t   target,
+                         ssg_member_id_t   ssg_target,
                          ssg_group_id_t    gid,
                          margo_instance_id mid,
                          int               shutdown,

--- a/perf-regression/ssg-test-separate-group-attach.c
+++ b/perf-regression/ssg-test-separate-group-attach.c
@@ -10,7 +10,7 @@ int main(int argc, char** argv)
     hg_addr_t         remote_addr = HG_ADDR_NULL;
     ssg_group_id_t    gid;
     margo_instance_id mid;
-    ssg_member_id_t   target;
+    ssg_member_id_t   ssg_target;
 
     MPI_Init(&argc, &argv);
 
@@ -29,9 +29,9 @@ int main(int argc, char** argv)
     ssg_group_dump(gid);
     fprintf(stderr, "        dumped...\n");
 
-    ret = ssg_get_group_member_id_from_rank(gid, 0, &target);
+    ret = ssg_get_group_member_id_from_rank(gid, 0, &ssg_target);
     assert(ret == SSG_SUCCESS);
-    ret = ssg_get_group_member_addr(gid, target, &remote_addr);
+    ret = ssg_get_group_member_addr(gid, ssg_target, &remote_addr);
     assert(ret == SSG_SUCCESS);
 
     ret = margo_shutdown_remote_instance(mid, remote_addr);

--- a/tests/cpu.plt
+++ b/tests/cpu.plt
@@ -1,7 +1,7 @@
 #set data style lines
 #set style data linespoints
 set xlabel 'Number of ULTs'
-set ylabel 'Eventual rate (ops/s)'
+set ylabel 'CPU time (s)'
 set term png medium
 #set term po eps mono dashed "Helvetica" 16
 #set term post eps color "Times-Roman" 20
@@ -15,4 +15,4 @@ OUTFILE=ARG2
 
 set yrange [0:]
 set output OUTFILE
-plot INFILE using 1:4 with lines
+plot INFILE using 1:5 with lines

--- a/tests/plot-abt-eventual-bench.sh
+++ b/tests/plot-abt-eventual-bench.sh
@@ -11,5 +11,6 @@ DAT=$1
 # itself, which is where the gnuplot scripts are that we want to use
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-gnuplot -c $SCRIPT_DIR/rate.plt $DAT $DAT.rate.eog
+gnuplot -c $SCRIPT_DIR/rate.plt $DAT $DAT.rate.png
+gnuplot -c $SCRIPT_DIR/cpu.plt $DAT $DAT.cpu.png
 

--- a/tests/plot-abt-eventual-bench.sh
+++ b/tests/plot-abt-eventual-bench.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: plot-abt-eventual-bench.sh <data file>"
+    exit 1
+fi
+
+DAT=$1
+
+# stack exchange says I can do this to find the location of the script
+# itself, which is where the gnuplot scripts are that we want to use
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+gnuplot -c $SCRIPT_DIR/rate.plt $DAT $DAT.rate.eog
+

--- a/tests/rate.plt
+++ b/tests/rate.plt
@@ -1,0 +1,17 @@
+#set data style lines
+#set style data linespoints
+set xlabel 'Number of ULTs'
+set ylabel 'Eventual rate (ops/s)'
+set term png medium
+#set term po eps mono dashed "Helvetica" 16
+#set term post eps color "Times-Roman" 20
+#set size 1.4,1.4
+#set key right bottom
+#set pointsize 2
+set key off
+
+INFILE=ARG1
+OUTFILE=ARG2
+
+set output OUTFILE
+plot INFILE using 1:4 with lines

--- a/tests/sweep-abt-eventual-bench.sh
+++ b/tests/sweep-abt-eventual-bench.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-if [ "$#" -ne 1 ]; then
+if [ "$#" -eq 0 ]; then
     echo "Usage: sweep-abt-eventual-bench.sh <executable>"
     exit 1
 fi
 
-EXE=$1
+EXE=$@
 OUTFILE=sweep-abt-eventual-bench.$$.dat
 
 echo writing results to $OUTFILE
 
-# sweep through number of ULTs in increments of 100 from 100 to 1000
-for i in `seq 100 100 1000`; do
+# sweep through number of ULTs in increments of 100 from 250 to 4850 (20 points)
+for  i in `seq 100 250 4850`; do
     echo ... running benchmark with $i ULTs
     $EXE -n $i >> $OUTFILE
 done

--- a/tests/sweep-abt-eventual-bench.sh
+++ b/tests/sweep-abt-eventual-bench.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: sweep-abt-eventual-bench.sh <executable>"
+    exit 1
+fi
+
+EXE=$1
+OUTFILE=sweep-abt-eventual-bench.$$.dat
+
+echo writing results to $OUTFILE
+
+# sweep through number of ULTs in increments of 100 from 100 to 1000
+for i in `seq 100 100 1000`; do
+    echo ... running benchmark with $i ULTs
+    $EXE -n $i >> $OUTFILE
+done
+
+echo results are in $OUTFILE


### PR DESCRIPTION
This adds a benchmark called `abt-eventual-benchmark` that measures how well we can create/wait/set/destroy concurrent eventuals.  It approximates a concurrent mochi provider workload by creating N concurrent threads, each of which (in a loop) creates detached sub-threads that `margo_thread_sleep()` for a specified amount of time before setting an eventual and exiting.  The sleep is a stand-in for waiting on network activity.

Example, with a duration of 5 seconds, a sleep interval of 1 ms, and 16 ULTs:
```
> ./abt-eventual-bench -d 5 -i 1 -n 16
#<num_ults>	<test_duration_sec>	<interval_msec>	<ops/s>	<cpu_time_sec>
16	5	1	15952.800000	4.255606
```
The above example shows 16 ULTs getting nearly 16,000 operations per second, which is pretty much ideal (each can do 1000 per second if everything is working right because there is a 1ms delay in each operation).  The last column shows CPU time.  In this case a 5 second run took 4.2 seconds of user-space CPU time, which is not expected.

These results are most interesting if you sweep across a range of ULT counts to see how behavior changes with scale.  There are scripts included in this PR to do this and plot the results for an example scenario.  The scripts are in the tests/ subdirectory.  The first takes the eventual executable as it's argument (so that it can account for different build directories).  The second takes the .dat file produced by the first script as it's argument and produces two plots.
```
> tests/sweep-abt-eventual-bench.sh build/perf-regression/abt-eventual-bench
writing results to sweep-abt-eventual-bench.1122789.dat
... running benchmark with 100 ULTs
... running benchmark with 200 ULTs
... running benchmark with 300 ULTs
... running benchmark with 400 ULTs
... running benchmark with 500 ULTs
... running benchmark with 600 ULTs
... running benchmark with 700 ULTs
... running benchmark with 800 ULTs
... running benchmark with 900 ULTs
... running benchmark with 1000 ULTs
results are in sweep-abt-eventual-bench.1122789.dat
> tests/plot-abt-eventual-bench.sh sweep-abt-eventual-bench.1122789.dat
> ls *.png
sweep-abt-eventual-bench.1122789.dat.cpu.png
sweep-abt-eventual-bench.1122789.dat.rate.png
```
Example plots, showing high cpu usage in each configuration.   The eventual rate climbs linearly with the number of ULTs (as expected) until 500 concurrent ULTs, at which point throughput starts dropping rather climbing or plateauing.

![sweep-abt-eventual-bench 1122789 dat cpu](https://user-images.githubusercontent.com/5541937/153058728-3134f873-0faf-45b5-9647-10ce4be2ce1f.png)
![sweep-abt-eventual-bench 1122789 dat rate](https://user-images.githubusercontent.com/5541937/153058731-5c967c2e-2de2-4d1f-af32-952007035e01.png)

The above example is from a laptop with a debugging build; we need to repeat this on real systems.

This benchmark only uses one execution stream (the primary one) so throughput will be limited eventually by how many concurrent ULTs it can keep busy.

Before merging this we need to make sure the benchmark is working correctly, clean up the code a little, and capture instructions in a README.
