### PR TITLE
Declare our file system requirements

### DIFF
--- a/perf-regression/cooley/bake-regression.qsub
+++ b/perf-regression/cooley/bake-regression.qsub
@@ -4,6 +4,7 @@
 #COBALT --mode script
 #COBALT -A radix-io
 #COBALT -q ibleaf3-debug
+#COBALT --attrs filesystems=home
 
 export HOME=$SANDBOX
 . $SANDBOX/spack/share/spack/setup-env.sh

--- a/perf-regression/cooley/margo-regression-tcp.qsub
+++ b/perf-regression/cooley/margo-regression-tcp.qsub
@@ -4,6 +4,7 @@
 #COBALT --mode script
 #COBALT -A radix-io
 #COBALT -q ibleaf3-debug
+#COBALT --attrs filesystems=home
 
 export HOME=$SANDBOX
 . $SANDBOX/spack/share/spack/setup-env.sh

--- a/perf-regression/cooley/margo-regression.qsub
+++ b/perf-regression/cooley/margo-regression.qsub
@@ -4,6 +4,7 @@
 #COBALT --mode script
 #COBALT -A radix-io
 #COBALT -q ibleaf3-debug
+#COBALT --attrs filesystems=home
 
 export HOME=$SANDBOX
 . $SANDBOX/spack/share/spack/setup-env.sh

--- a/perf-regression/cooley/margo-vector-regression.qsub
+++ b/perf-regression/cooley/margo-vector-regression.qsub
@@ -4,6 +4,7 @@
 #COBALT --mode script
 #COBALT -A radix-io
 #COBALT -q ibleaf3-debug
+#COBALT --attrs filesystems=home
 
 export HOME=$SANDBOX
 . $SANDBOX/spack/share/spack/setup-env.sh

--- a/perf-regression/cooley/pmdk-regression.qsub
+++ b/perf-regression/cooley/pmdk-regression.qsub
@@ -4,6 +4,7 @@
 #COBALT --mode script
 #COBALT -A radix-io
 #COBALT -q ibleaf3-debug
+#COBALT --attrs filesystems=home
 
 export HOME=$SANDBOX
 . $SANDBOX/spack/share/spack/setup-env.sh


### PR DESCRIPTION
I noticed the nightly tests on cooley weren't running because 'grand' is out of comission -- but none of these tests need grand, eagle, or really any file system other than /home right?