### PR TITLE
Add example script and bedrock config for running IOR with Mobject

### DIFF
--- a/perf-regression/polaris/README.md
+++ b/perf-regression/polaris/README.md
@@ -1,0 +1,43 @@
+This directory contains scripts and files for running various Mochi
+tests on Argonne's Polaris system.
+
+`mobject_bedrock.json` is a simple bedrock configuration file used
+for configuring the various components of Mobject.
+
+`run_ior.qsub` is used for running IOR with Mobject while utilizing
+Mochi Bake's file backend to write to Polaris' node-local SSDs at
+`/local/scratch`. The script assumes that:
+
+ * The user has spack installed at `$HOME/spack`
+ * The user has setup a spack environment called "mochi-env" by  
+   using the existing Mochi [platform configuration file for Polaris](https://github.com/mochi-hpc-experiments/platform-configurations/blob/main/ANL/Polaris/spack.yaml)
+
+This script may need to be [edited](run_ior.qsub#L25-L28) if spack
+is installed in a different location or a differently named spack
+environment is used (or if a spack environment isn't used).
+
+This script also assumes that IOR has been installed with spack
+according to the spec `ior+mobject ^mobject@main`. Instructions for
+setting up a spack environment called "mochi-env" and installing
+IOR within that environment can be found at [https://github.com/mochi-hpc/mobject/blob/main/doc/FAQ.md](https://github.com/mochi-hpc/mobject/blob/main/doc/FAQ.md).
+
+
+`run_ior_hdf5_rados.qsub` is used for running IOR with Mobject through
+the HDF5 RADOS VOL connector; it also is setup to write to Polaris'
+node-local SSDs with Mochi Bake's file backend. The script assumes
+that:
+
+ * The user has spack installed at `$HOME/spack`
+ * The user has setup a spack environment called "mochi-env" by  
+   using the existing Mochi [platform configuration file for Polaris](https://github.com/mochi-hpc-experiments/platform-configurations/blob/main/ANL/Polaris/spack.yaml)
+
+This script may need to be [edited](run_ior_hdf5_rados.qsub#L25-L28) if spack
+is installed in a different location or a differently named spack
+environment is used (or if a spack environment isn't used).
+
+This script also assumes that the HDF5 RADOS VOL connector has been
+installed according to the spack spec `hdf5-rados` and that IOR has
+been installed with spack according to the spec `ior@hdf5-rados`.
+Instructions for setting up a spack environment called "mochi-env"
+and installed the VOL connector in conjunction with IOR can be found
+at [https://github.com/mochi-hpc/mobject/blob/main/doc/FAQ.md](https://github.com/mochi-hpc/mobject/blob/main/doc/FAQ.md).

--- a/perf-regression/polaris/mobject_bedrock.json
+++ b/perf-regression/polaris/mobject_bedrock.json
@@ -1,0 +1,90 @@
+{
+    "ssg" : [
+        {
+            "name" : "mobject",
+            "bootstrap" : "init",
+            "group_file" : "mobject.ssg",
+            "swim" : { "disabled" : true }
+        }
+    ],
+    "libraries" : {
+        "yokan"   : "libyokan-bedrock-module.so",
+        "bake"    : "libbake-bedrock.so",
+        "mobject" : "libmobject-bedrock.so"
+    },
+    "abt_io" : [
+        {
+            "name" : "bake_abt_io",
+            "pool" : "__primary__"
+        }
+    ],
+    "providers" : [
+        {
+            "name" : "metadata",
+            "type" : "yokan",
+            "provider_id" : 0,
+            "config" : {
+                "databases" : [
+                    {
+                        "name" : "mobject_oid_map",
+                        "type" : "map",
+                        "config" : {
+                            "comparator" : "libmobject-comparators.so:mobject_oid_map_compare"
+                        }
+                    },
+                    {
+                        "name" : "mobject_name_map",
+                        "type" : "map",
+                        "config" : {
+                            "comparator" : "libmobject-comparators.so:mobject_name_map_compare"
+                        }
+                    },
+                    {
+                        "name" : "mobject_seg_map",
+                        "type" : "map",
+                        "config" : {
+                            "comparator" : "libmobject-comparators.so:mobject_seg_map_compare"
+                        }
+                    },
+                    {
+                        "name" : "mobject_omap_map",
+                        "type" : "map",
+                        "config" : {
+                            "comparator" : "libmobject-comparators.so:mobject_omap_map_compare"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name" : "storage",
+            "type" : "bake",
+            "provider_id" : 0,
+            "config" : {
+                "pipeline_enable" : true,
+                "pipeline_npools" : 4,
+                "pipeline_nbuffers_per_pool" : 32,
+                "pipeline_first_buffer_size" : 65536,
+                "pipeline_multiplier" : 4,
+                "file_backend": {
+                    "targets": [
+                        "/local/scratch/mobject-target.dat"
+                    ]
+                }
+            },
+            "dependencies" : {
+                "abt_io" : "bake_abt_io"
+            }
+        },
+        {
+            "name" : "coordinator",
+            "type" : "mobject",
+            "provider_id" : 1,
+            "config" : {},
+            "dependencies" : {
+                "bake_provider_handle" : "storage@local",
+                "yokan_provider_handle" : "metadata@local"
+            }
+        }
+    ]
+}

--- a/perf-regression/polaris/run_ior.qsub
+++ b/perf-regression/polaris/run_ior.qsub
@@ -1,0 +1,52 @@
+#!/bin/bash
+#PBS -l select=1:system=polaris
+#PBS -l place=scatter
+#PBS -l walltime=0:10:00
+#PBS -l filesystems=home:grand
+#PBS -q debug
+#PBS -A radix-io
+
+export MOBJECT_CLUSTER_FILE=mobject.ssg
+
+IOR_TRANSFER_SIZE="64k"
+IOR_BLOCK_SIZE="128k"
+
+set -eu
+
+# Change to working directory
+cd ${PBS_O_WORKDIR}
+
+# note: disable registration cache for verbs provider for now; see
+#       discussion in https://github.com/ofiwg/libfabric/issues/5244
+export FI_MR_CACHE_MAX_COUNT=0
+# use shared recv context in RXM; should improve scalability
+export FI_OFI_RXM_USE_SRX=1
+
+echo "Setting up spack"
+source $HOME/spack/share/spack/setup-env.sh
+echo "Activating env"
+spack env activate mochi-env
+spack find -fN
+
+NNODES=`wc -l < $PBS_NODEFILE`
+NRANKS_PER_NODE=32
+
+NRANKS=$(( NNODES * NRANKS_PER_NODE ))
+
+echo "Starting server"
+
+# Start Mochi server in background via Bedrock using an example configuration and Verbs as the provider
+mpiexec -n 1 bedrock -c mobject_bedrock.json verbs:// &
+
+# Give the server a chance to setup
+sleep 5
+
+echo "Running IOR"
+
+# Run IOR on 1 node with 32 ranks
+#mpiexec -n ${NRANKS} --ppn ${NRANKS_PER_NODE} ior -a RADOS -t ${IOR_TRANSFER_SIZE} -b ${IOR_BLOCK_SIZE} --rados.user=foo --rados.pool=bar --rados.conf=baz
+mpiexec -n ${NRANKS} ior -a RADOS -t ${IOR_TRANSFER_SIZE} -b ${IOR_BLOCK_SIZE} --rados.user=foo --rados.pool=bar --rados.conf=baz
+
+# Tear down bedrock server
+bedrock-shutdown -s $MOBJECT_CLUSTER_FILE verbs://
+

--- a/perf-regression/polaris/run_ior.qsub
+++ b/perf-regression/polaris/run_ior.qsub
@@ -2,7 +2,7 @@
 #PBS -l select=1:system=polaris
 #PBS -l place=scatter
 #PBS -l walltime=0:10:00
-#PBS -l filesystems=home:grand
+#PBS -l filesystems=home
 #PBS -q debug
 #PBS -A radix-io
 
@@ -27,6 +27,9 @@ source $HOME/spack/share/spack/setup-env.sh
 echo "Activating env"
 spack env activate mochi-env
 spack find -fN
+
+# Just in case...
+spack load ior+mobject
 
 NNODES=`wc -l < $PBS_NODEFILE`
 NRANKS_PER_NODE=32

--- a/perf-regression/polaris/run_ior_hdf5_rados.qsub
+++ b/perf-regression/polaris/run_ior_hdf5_rados.qsub
@@ -2,7 +2,7 @@
 #PBS -l select=1:system=polaris
 #PBS -l place=scatter
 #PBS -l walltime=0:10:00
-#PBS -l filesystems=home:grand
+#PBS -l filesystems=home
 #PBS -q debug
 #PBS -A radix-io
 
@@ -29,6 +29,7 @@ spack env activate mochi-env
 spack find -fN
 
 # Just in case...
+spack load ior+hdf5
 spack load hdf5-rados
 
 NNODES=`wc -l < $PBS_NODEFILE`

--- a/perf-regression/polaris/run_ior_hdf5_rados.qsub
+++ b/perf-regression/polaris/run_ior_hdf5_rados.qsub
@@ -1,0 +1,63 @@
+#!/bin/bash
+#PBS -l select=1:system=polaris
+#PBS -l place=scatter
+#PBS -l walltime=0:10:00
+#PBS -l filesystems=home:grand
+#PBS -q debug
+#PBS -A radix-io
+
+export MOBJECT_CLUSTER_FILE=mobject.ssg
+
+IOR_TRANSFER_SIZE="64k"
+IOR_BLOCK_SIZE="128k"
+
+set -eu
+
+# Change to working directory
+cd ${PBS_O_WORKDIR}
+
+# note: disable registration cache for verbs provider for now; see
+#       discussion in https://github.com/ofiwg/libfabric/issues/5244
+export FI_MR_CACHE_MAX_COUNT=0
+# use shared recv context in RXM; should improve scalability
+export FI_OFI_RXM_USE_SRX=1
+
+echo "Setting up spack"
+source $HOME/spack/share/spack/setup-env.sh
+echo "Activating env"
+spack env activate mochi-env
+spack find -fN
+
+# Just in case...
+spack load hdf5-rados
+
+NNODES=`wc -l < $PBS_NODEFILE`
+NRANKS_PER_NODE=32
+
+NRANKS=$(( NNODES * NRANKS_PER_NODE ))
+
+echo "Starting server"
+
+# Start Mochi server in background via Bedrock using an example configuration and Verbs as the provider
+mpiexec -n 1 bedrock -c mobject_bedrock.json verbs:// &
+
+# Give the server a chance to setup
+sleep 5
+
+# Export environment variables to load HDF5 RADOS VOL connector
+export HDF5_VOL_CONNECTOR="rados"
+export HDF5_PLUGIN_PATH="`spack location -i hdf5-rados`/lib"
+
+echo "Set HDF5 plugin path to `spack location -i hdf5-rados`/lib"
+
+echo "Running IOR"
+
+# Run IOR on 1 node with 32 ranks
+
+# Avoid using HDF5 chunk size option until RADOS VOL can be run against latest IOR development branch
+#mpiexec -n ${NRANKS} ior -a HDF5 -t ${IOR_TRANSFER_SIZE} -b ${IOR_BLOCK_SIZE} --hdf5.chunkSize=8192
+mpiexec -n ${NRANKS} ior -a HDF5 -t ${IOR_TRANSFER_SIZE} -b ${IOR_BLOCK_SIZE}
+
+# Tear down bedrock server
+bedrock-shutdown -s $MOBJECT_CLUSTER_FILE verbs://
+


### PR DESCRIPTION
Will add a README detailing the qsub script once https://github.com/mochi-hpc-experiments/mochi-tests/pull/51 is updated and merged so as to not conflict with it.

Seems to run IOR fine for the intial write call, but then on the read I start getting:

```
[error] bake_proxy_read invalid read of 0 (requested=65536)
[error] [mobject] read_op_exec_read:223: baje_proxy_read invalid read of 0 (requested 65536)
ior ERROR: unable to read RADOS object, errno 0, Success (aiori-RADOS.c:224)
```