### PR TITLE
misc theta-gpu job script cleanups

### DIFF
--- a/perf-regression/theta-gpu/gpu-qsub
+++ b/perf-regression/theta-gpu/gpu-qsub
@@ -31,7 +31,7 @@ echo "=== CREATE DIRECTORIES AND DOWNLOAD CODE ==="
 # where you want to run the tests.
 ORIGIN=$PWD
 # Scratch area for builds
-SANDBOX=$PWD/sb-gpu
+SANDBOX=$PWD/sb-gpu-$$
 PREFIX=$SANDBOX/install
 
 # modify HOME env variable so that we don't perturb ~/.spack/ files for the
@@ -51,9 +51,8 @@ echo "=== SET UP SPACK ENVIRONMENT ==="
 . $SANDBOX/spack/share/spack/setup-env.sh
 spack env create gpu-mochi-regression $SANDBOX/platform-configurations/ANL/ThetaGPU/spack.yaml
 spack env activate gpu-mochi-regression
-
+spack repo rm /path/to/mochi-spack-packages
 spack repo add $SANDBOX/mochi-spack-packages
-spack install mochi-margo@develop
 spack add mochi-ssg@develop ^openmpi
 spack install
 spack find


### PR DESCRIPTION
- uniquify sandbox directory so that duplicate runs don't collide
- remove dummy spack repo path from spack env recipe to avoid warning
- don't explicitly install mochi-margo (this is not allowed in a spack env without adding to root specs); it is pulled in via mochi-ssg deependency anyway

@jhendersonHDF and @vchoi-hdfgroup does this look Ok to you?  I'm trying to get it running and got closer after these changes, but then I still hit errors that look like this before it finishes installing everything:

```
==> Error: AttributeError: Query of package 'openmpi' for 'headers' failed
        prefix : None
        spec : openmpi@4.0.5%gcc@9.4.0~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~java~legacylaunchers~lustre~memchecker+romio+rsh~singularity+static+vt+wrapper-rpath build_system=autotools fabrics=none patches=60ce20b schedulers=none arch=linux-ubuntu20.04-zen2
        queried as : openmpi
        extra parameters : []

The 'mochi-ssg' package cannot find an attribute while trying to build from sources. This might be due to a change in Spack's package format to support multiple build-systems for a single package. You can fix this by updating the build recipe, and you can also report the issue as a bug. More information at https://spack.readthedocs.io/en/latest/packaging_guide.html#installation-procedure
==> Error: mochi-ssg-develop-pkmj42xollb5zhbxervo22vlt3rln36o: AttributeError: Query of package 'openmpi' for 'headers' failed
        prefix : None
```

Possibly this is a problem triggered by a recent spack update if you are not seeing it.