### PR TITLE
Add script for running Margo GPU test on Polaris

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,7 +130,7 @@ AM_CONDITIONAL([HAVE_PMDK], [test "x${have_libpmemobj}" = x1 && test "x${have_ar
 AM_CONDITIONAL([HAVE_SSG], [test "x${have_ssg}" = x1 && test "x${have_ssg_mpi}" = x1])
 AM_CONDITIONAL([HAVE_MPI], [test "x${have_mpi}" = x1])
 AM_CONDITIONAL([HAVE_GPU_TESTING], [test "x${have_nvcc}" = x1 && test "x${have_mpi}" = x1])
-
+AM_CONDITIONAL([HAVE_MPICH_DIR], [test "$MPICH_DIR" != "0"])
 
 
 AC_CONFIG_FILES([Makefile])

--- a/perf-regression/Makefile.subdir
+++ b/perf-regression/Makefile.subdir
@@ -14,7 +14,12 @@ CUDA_CFLAGS := $(subst -pthread,,$(CFLAGS))
 #Set up mpi path for include/lib
 MPICC := $(shell which $(CC))
 STRIP_LAST = $(patsubst %/,%,$(dir $(MPICC)))
+
+if HAVE_MPICH_DIR
+MPICC_PATH = $(MPICH_DIR)
+else
 MPICC_PATH = $(patsubst %/,%,$(dir $(STRIP_LAST)))
+endif
 
 perf-regression/gpu-margo-p2p-bw: perf-regression/gpu-margo-p2p-bw.cu
 	$(NVCC) -I. $(CUDA_CFLAGS) $(LIBS) -I$(MPICC_PATH)/include -L$(MPICC_PATH)/lib -lmpi $< -o $@

--- a/perf-regression/polaris/README.md
+++ b/perf-regression/polaris/README.md
@@ -8,18 +8,19 @@ for configuring the various components of Mobject.
 Mochi Bake's file backend to write to Polaris' node-local SSDs at
 `/local/scratch`. The script assumes that:
 
- * The user has spack installed at `$HOME/spack`
- * The user has setup a spack environment called "mochi-env" by  
+ * The user has Spack installed at `$HOME/spack`
+ * The user has setup a Spack environment called "mochi-env" by  
    using the existing Mochi [platform configuration file for Polaris](https://github.com/mochi-hpc-experiments/platform-configurations/blob/main/ANL/Polaris/spack.yaml)
 
-This script may need to be [edited](run_ior.qsub#L25-L28) if spack
-is installed in a different location or a differently named spack
-environment is used (or if a spack environment isn't used).
+This script may need to be [edited](run_ior.qsub#L25-L28) if Spack
+is installed in a different location or a differently named Spack
+environment is used (or if a Spack environment isn't used).
 
-This script also assumes that IOR has been installed with spack
-according to the spec `ior@develop+mobject ^mobject@develop`. Instructions
-for setting up a spack environment called "mochi-env" and installing
-IOR within that environment can be found at [https://github.com/mochi-hpc/mobject/blob/main/doc/FAQ.md](https://github.com/mochi-hpc/mobject/blob/main/doc/FAQ.md).
+This script also assumes that IOR has been installed with Spack
+according to the spec `ior@develop+mobject ^mobject@develop`.
+Instructions for setting up a Spack environment called "mochi-env"
+and installing IOR within that environment can be found at
+[https://github.com/mochi-hpc/mobject/blob/main/doc/FAQ.md](https://github.com/mochi-hpc/mobject/blob/main/doc/FAQ.md).
 
 
 `run_ior_hdf5_rados.qsub` is used for running IOR with Mobject through
@@ -27,17 +28,38 @@ the HDF5 RADOS VOL connector; it also is setup to write to Polaris'
 node-local SSDs with Mochi Bake's file backend. The script assumes
 that:
 
- * The user has spack installed at `$HOME/spack`
- * The user has setup a spack environment called "mochi-env" by  
+ * The user has Spack installed at `$HOME/spack`
+ * The user has setup a Spack environment called "mochi-env" by  
    using the existing Mochi [platform configuration file for Polaris](https://github.com/mochi-hpc-experiments/platform-configurations/blob/main/ANL/Polaris/spack.yaml)
 
-This script may need to be [edited](run_ior_hdf5_rados.qsub#L25-L28) if spack
-is installed in a different location or a differently named spack
-environment is used (or if a spack environment isn't used).
+This script may need to be [edited](run_ior_hdf5_rados.qsub#L25-L28)
+if Spack is installed in a different location or a differently named
+Spack environment is used (or if a Spack environment isn't used).
 
 This script also assumes that the HDF5 RADOS VOL connector has been
-installed according to the spack spec `hdf5-rados ^mobject@develop` and that
+installed according to the Spack spec `hdf5-rados ^mobject@develop` and that
 IOR has been installed with Spack according to the spec `ior@develop+hdf5 ^hdf5@develop-1.13`.
-Instructions for setting up a spack environment called "mochi-env"
+Instructions for setting up a Spack environment called "mochi-env"
 and installing the VOL connector in conjunction with IOR can be found
 at [https://github.com/mochi-hpc/mobject/blob/main/doc/FAQ.md](https://github.com/mochi-hpc/mobject/blob/main/doc/FAQ.md).
+
+
+`run_gpu_margo_p2p_bw.qsub` is used for running the GPU-aware Mochi
+Margo point-to-point bandwidth test. The script assumes that:
+
+ * The user has Spack installed at `$HOME/spack`
+ * The user has setup a Spack environment called "mochi-env" by  
+   using the existing Mochi [platform configuration file for Polaris](https://github.com/mochi-hpc-experiments/platform-configurations/blob/main/ANL/Polaris/spack.yaml)
+
+This script may need to be [edited](run_gpu_margo_p2p_bw.qsub#L25-L28)
+if Spack is installed in a different location or a differently named
+Spack environment is used (or if a Spack environment isn't used).
+
+This script also assumes that the user has already built and installed
+the Mochi tests from source with a Mochi Margo installation that uses
+a CUDA-enabled libfabric version. Margo can be installed in this way
+with Spack according to the spec `mochi-margo@develop ^libfabric+cuda`.
+The script simply has a variable called `MOCHI_TESTS_INSTALL` that should
+be edited to the directory where the Mochi tests have been installed
+and wherein the `gpu-margo-p2p-bw` program is available in the `bin`
+directory.

--- a/perf-regression/polaris/README.md
+++ b/perf-regression/polaris/README.md
@@ -44,22 +44,53 @@ and installing the VOL connector in conjunction with IOR can be found
 at [https://github.com/mochi-hpc/mobject/blob/main/doc/FAQ.md](https://github.com/mochi-hpc/mobject/blob/main/doc/FAQ.md).
 
 
-`run_gpu_margo_p2p_bw.qsub` is used for running the GPU-aware Mochi
-Margo point-to-point bandwidth test. The script assumes that:
+`run_gpu_margo_p2p_bw.qsub` is a simple script used for running the
+GPU-aware Mochi Margo point-to-point bandwidth test on Polaris. This
+script should be edited so that the `MOCHI_TESTS_INSTALL` variable
+points to the directory where the Mochi Margo tests have been installed
+and wherein the `gpu-margo-p2p-bw` program is available under the `bin`
+directory. This script may also need to be [edited](run_gpu_margo_p2p_bw.qsub#L25-L28)
+if Spack is installed in a different location or a differently named
+Spack environment is used (or if a Spack environment isn't used).
+The script assumes that:
 
  * The user has Spack installed at `$HOME/spack`
  * The user has setup a Spack environment called "mochi-env" by  
    using the existing Mochi [platform configuration file for Polaris](https://github.com/mochi-hpc-experiments/platform-configurations/blob/main/ANL/Polaris/spack.yaml)
+ * The user has installed Mochi Margo with SSG and CUDA-enabled libfabric
+   support. Once the user has a Spack environment setup and activated
+   (`spack env activate mochi-env`) from the previous point, installing
+   Mochi Margo this way can be done with Spack by running
+   `spack add mochi-margo@develop ^libfabric+cuda`, `spack add mochi-ssg`,
+   `spack install`
+ * The user has built and installed the Mochi Margo tests from source
+   and installed them on the system somewhere. The user may need to run
+   `spack load mochi-margo` before trying to install the Mochi Margo
+   tests. The user may also need to run `module load cray-mpich` and set
+   `CC=cc` before running `configure` when building the tests in order for
+   MPI support to be properly detected.
 
-This script may need to be [edited](run_gpu_margo_p2p_bw.qsub#L25-L28)
-if Spack is installed in a different location or a differently named
-Spack environment is used (or if a Spack environment isn't used).
+**NOTE:** The Polaris platform configuration file currently uses GCC
+for compilation, whereas the system's default compilers are the `nvhpc`
+compilers. To ensure that everything is built with the same compiler,
+this means that the user should probably switch to the GNU programming
+environment on Polaris before building the Mochi Margo tests. This can
+be done by running:
 
-This script also assumes that the user has already built and installed
-the Mochi tests from source with a Mochi Margo installation that uses
-a CUDA-enabled libfabric version. Margo can be installed in this way
-with Spack according to the spec `mochi-margo@develop ^libfabric+cuda`.
-The script simply has a variable called `MOCHI_TESTS_INSTALL` that should
-be edited to the directory where the Mochi tests have been installed
-and wherein the `gpu-margo-p2p-bw` program is available in the `bin`
-directory.
+    module swap PrgEnv-nvhpc PrgEnv-gnu
+    module load nvhpc-mixed (optional to have nvhpc compilers still available)
+
+Further, the default `nvcc` compiler that is loaded into the system
+path appears to be too new to correctly compile the CUDA code in the
+Mochi Margo point-to-point bandwidth test so that it can run on the
+GPUs attached to the compute nodes. If running the
+`run_gpu_margo_p2p_bw.qsub` script gives output similar to the following:
+
+    Error: unable to cudaMalloc 524288000 byte buffer
+
+this is a sign that the Mochi Margo test code was compiled with the
+newer `nvcc`. To fix this issue, the user should run:
+
+    module load cudatoolkit-standalone/11.4.4
+
+and then recompile the test code.

--- a/perf-regression/polaris/run_gpu_margo_p2p_bw.qsub
+++ b/perf-regression/polaris/run_gpu_margo_p2p_bw.qsub
@@ -34,10 +34,10 @@ spack load mochi-margo@develop ^libfabric+cuda
 echo "Running Margo P2P BW GPU Test"
 
 echo "=== Testing transfer from GPU memory of Host A to GPU memory of Host B ==="
-mpiexec -n 2 -ppn 1 $MOCHI_TESTS_INSTALL/bin/gpu-margo-p2p-bw -x 4096 -n "ofi+verbs://" -c 1 -D 10
+mpiexec -n 2 -ppn 1 $MOCHI_TESTS_INSTALL/bin/gpu-margo-p2p-bw -X 524288000 -x 1048576 -n "ofi+verbs://" -c 1 -D 10
 
 echo "=== Testing transfer from GPU memory of Host A to main memory of Host B ==="
-mpiexec -n 2 -ppn 1 $MOCHI_TESTS_INSTALL/bin/gpu-margo-p2p-bw -x 4096 -n "ofi+verbs://" -c 1 -D 10 -j
+mpiexec -n 2 -ppn 1 $MOCHI_TESTS_INSTALL/bin/gpu-margo-p2p-bw -X 524288000 -x 1048576 -n "ofi+verbs://" -c 1 -D 10 -j
 
 echo "=== Testing transfer from main memory of Host A to GPU memory of Host B ==="
-mpiexec -n 2 -ppn 1 $MOCHI_TESTS_INSTALL/bin/gpu-margo-p2p-bw -x 4096 -n "ofi+verbs://" -c 1 -D 10 -k
+mpiexec -n 2 -ppn 1 $MOCHI_TESTS_INSTALL/bin/gpu-margo-p2p-bw -X 524288000 -x 1048576 -n "ofi+verbs://" -c 1 -D 10 -k

--- a/perf-regression/polaris/run_gpu_margo_p2p_bw.qsub
+++ b/perf-regression/polaris/run_gpu_margo_p2p_bw.qsub
@@ -1,0 +1,43 @@
+#!/bin/bash
+#PBS -l select=2:system=polaris
+#PBS -l place=scatter
+#PBS -l walltime=0:10:00
+#PBS -l filesystems=home
+#PBS -q debug
+#PBS -A radix-io
+
+# Set to location of installed mochi tests directory
+# where the gpu-margo-p2p-bw program should be available
+# in the 'bin' directory
+MOCHI_TESTS_INSTALL=/home/jhendersonhdf/mochi-tests-build
+
+set -eu
+
+# Change to working directory
+cd ${PBS_O_WORKDIR}
+
+# note: disable registration cache for verbs provider for now; see
+#       discussion in https://github.com/ofiwg/libfabric/issues/5244
+export FI_MR_CACHE_MAX_COUNT=0
+# use shared recv context in RXM; should improve scalability
+export FI_OFI_RXM_USE_SRX=1
+
+echo "Setting up Spack"
+source $HOME/spack/share/spack/setup-env.sh
+echo "Activating env"
+spack env activate mochi-env
+spack find -fN
+
+# Just in case..
+spack load mochi-margo@develop ^libfabric+cuda
+
+echo "Running Margo P2P BW GPU Test"
+
+echo "=== Testing transfer from GPU memory of Host A to GPU memory of Host B ==="
+mpiexec -n 2 -ppn 1 $MOCHI_TESTS_INSTALL/bin/gpu-margo-p2p-bw -x 4096 -n "ofi+verbs://" -c 1 -D 10
+
+echo "=== Testing transfer from GPU memory of Host A to main memory of Host B ==="
+mpiexec -n 2 -ppn 1 $MOCHI_TESTS_INSTALL/bin/gpu-margo-p2p-bw -x 4096 -n "ofi+verbs://" -c 1 -D 10 -j
+
+echo "=== Testing transfer from main memory of Host A to GPU memory of Host B ==="
+mpiexec -n 2 -ppn 1 $MOCHI_TESTS_INSTALL/bin/gpu-margo-p2p-bw -x 4096 -n "ofi+verbs://" -c 1 -D 10 -k

--- a/perf-regression/polaris/run_gpu_margo_p2p_bw.qsub
+++ b/perf-regression/polaris/run_gpu_margo_p2p_bw.qsub
@@ -9,7 +9,7 @@
 # Set to location of installed mochi tests directory
 # where the gpu-margo-p2p-bw program should be available
 # in the 'bin' directory
-MOCHI_TESTS_INSTALL=/home/jhendersonhdf/mochi-tests-build
+MOCHI_TESTS_INSTALL=/path/to/mochi-tests-build
 
 set -eu
 


### PR DESCRIPTION
This may conflict with https://github.com/mochi-hpc-experiments/mochi-tests/pull/62 and it still has an issue in that running the test returns the error we've seen before with:

`Error: unable to cudaMalloc 2147483648 byte buffer`

but I wanted to get something initial up.